### PR TITLE
fix: remove useless ToC in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,6 @@
   <a href="https://discord.gg/fpUDwEMGwE">Discord</a>
 </p>
 
-## Table of Contents
-
-- [What's in This Repository](#whats-in-this-repository)
-- [Status](#status)
-- [Quick Start](#quick-start)
-- [Bugs and Feature Requests](#bugs-and-feature-requests)
-- [Contributing](#contributing)
-- [Community](#community)
-- [Copyright and license](#copyright-and-license)
-
 ## What’s in This Repository
 
 "openresource.dev" is the repository containing the code source deployed to https://openresource.dev.


### PR DESCRIPTION
### Description

This PR removes the ToC from the `README.md` which can be considered useless.

Indeed, as pointed out by @hiDeoo, GitHub interface already offers a similar approach:

![2023-04-21 13 34 41](https://user-images.githubusercontent.com/17381666/233626010-acc41b8a-d109-4d4f-aa8e-db5121a98160.gif)

Since this `README.md` won't be embedded in stores contrary to `README.md`s used for libraries, it's safe to remove it to avoid to maintain it.

### Type of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Open-reSource/openresource.dev/blob/main/CONTRIBUTING.md)
