### PR TITLE
feat(chapters): add previous/next buttons

### DIFF
--- a/src/pages/guide/[...slug].astro
+++ b/src/pages/guide/[...slug].astro
@@ -98,6 +98,18 @@ const { Content } = await entry.render();
         <div class="prose prose-slate mx-auto lg:prose-lg">
           <h1 class="font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-primary to-secondary pb-3">{ entry.data.title }</h1>
           <Content />
+          <div class="flex flex-col xs:flex-row justify-center gap-5 sm:mt-32 items-center mt-16">
+            {
+              entry.data.id > 1 && (
+                <a href={`/guide/${ orderedFilteredChapters[entry.data.id - 2].slug }`} class="btn btn-secondary">Previous chapter</a>
+              )
+            }
+            {
+              entry.data.id < orderedFilteredChapters.length && (
+                <a href={`/guide/${ orderedFilteredChapters[entry.data.id].slug }`} class="btn btn-secondary">Next chapter</a>
+              )
+            }
+          </div>
         </div>
       </div>
     </div>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,8 +1,15 @@
 /** @type {import('tailwindcss').Config} */
+
+const defaultTheme = require('tailwindcss/defaultTheme')
+
 module.exports = {
 	content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
 	theme: {
 		extend: {},
+		screens: {
+			'xs': '480px',
+			...defaultTheme.screens
+		}
 	},
 	plugins: [
 		require('@tailwindcss/typography'),


### PR DESCRIPTION
### Description

This PR adds a previous/next navigation to the chapters of the modules.
Their layout is vertical or horizontal depending on the screen size.
An xs breakpoint is added to the tailwind config to handle the layout change.

### Motivation & Context

While reading the entire module, it is useful to have a navigation to the previous and next chapters.

### Type of changes

- New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Open-reSource/openresource.dev/blob/main/CONTRIBUTING.md)


### [Live preview](https://main-branch-openresource-dev-git-main-jd-a-742fea-open-resource.vercel.app/guide/what-is-open-source/definition-of-open-source)
