### PR TITLE
ci: add npm dependencies caching

### DIFF
--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
+        with:
+          cache: npm
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
### Related issues

I did not bother creating an issue for this considering the size of the changes and the obvious impact it has, but I can if you really want to.

### Description

This pull request adds a caching mechanism of dependencies to the CI pipeline to speed up CI runs, use less compute resources and reduce the number of requests to the package manager registry.

### Motivation & Context

Installing dependencies can take a long time, especially on CI and even more when using `npm`. Thanks to deterministic lockfiles, most package managers dependencies can now be cached and reused between builds, e.g. with `npm`, `yarn`, `pnpm` and even non-JS package managers like `pip`, `nugget` and `cargo`, etc.

This is the reason why [`actions/cache`](https://github.com/actions/cache) is one of the most popular actions on GitHub Actions. Unfortunately, it is not as easy to configure as it's fairly generic and can be used for a lot of different things.

Luckily, [`actions/setup-node`](https://github.com/actions/setup-node) has an option to easily setup caching for `npm`, `yarn` and `pnpm` which will use `actions/cache` under the hood. This is the option enabled in this pull request.

After enabling this option, the first run of `Setup Node.js` step will automatically try to find a cache but will fail to do so as there is no cache yet:

```
npm cache is not found
```

At the end of the first run, in the `Post Setup Node.js` step, the cache will be created and stored for future runs, e.g.:

```
Cache Size: ~37 MB (39235052 B)
Cache saved successfully
Cache saved with the key: node-cache-Linux-npm-14cebebe398b910f0b54ec343dc1d95a04de9150251c352242dd092e24dc19494
```

The cache name is based on the OS, package manager used and a hash of the lockfile. This means that if the lockfile changes due to new, removed or updated dependencies, the cache will be invalidated and a new one will be created. Note that the `node_modules` folder is not actually cached but instead the [global stores](https://docs.npmjs.com/cli/v8/commands/npm-cache) used by the package managers are cached.

During a subsequent run, the cache will be found and restored, e.g.:

```
Cache Size: ~37 MB (39235052 B)
Cache restored successfully
Cache restored from key: node-cache-Linux-npm-14cebebe398b910f0b54ec343dc1d95a04de9150251c352242dd092e24dc19494
```

With the cache in place, the `Install dependencies` step will be much faster at this point.

If needed, more information about the caching mechanism can be found in the [`actions/setup-node` documentation](https://github.com/actions/setup-node#caching-global-packages-data)

### Type of changes

- Refactoring (non-breaking change)

### Checklist

- [X] I have read the [contributing guidelines](https://github.com/Open-reSource/openresource.dev/blob/main/CONTRIBUTING.md)
