### PR TITLE
feat: add showcase banner in `/` and `/showcase`

### DIFF
--- a/src/components/ShowcaseBanner.astro
+++ b/src/components/ShowcaseBanner.astro
@@ -1,0 +1,24 @@
+---
+const { classes } = Astro.props;
+---
+<section class={`bg-secondary-focus text-secondary-content not-prose ${classes}`}>
+  <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8 sm:py-12 xl:py-24">
+    <h2 class="text-2xl sm:text-3xl font-bold sm:text-center mb-8 sm:mb-12 xl:mb-16">Showcase your projects</h2>
+    <div class="flex gap-4 flex-col">
+      <div class="flex justify-center">
+        <p class="text-xl sm:text-2xl font-bold base-content max-w-xl sm:text-center">
+          Explore what the Open &#123;re&#125;Source community builds for the Open Source world.
+        </p>
+      </div>
+      <div class="flex justify-center">
+        <p class="text-xl sm:text-2xl base-content max-w-xl sm:text-center">
+          Submit your Open Source project(s), profiles or websites to the showcase and let the community discover your work.
+        </p>
+      </div>
+      <div class="flex flex-col xs:flex-row sm:justify-center gap-4 mt-8">
+        <a class="btn" href="https://github.com/orgs/Open-reSource/discussions/3" target="_blank" rel="noopener">Submit project(s)</a>
+        <a class="btn btn-outline text-primary-content" href="/showcase">Show project(s)</a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 export const prerender = true
 
+import ShowcaseBanner from '../components/ShowcaseBanner.astro';
 import Layout from '../layouts/Layout.astro';
 
 const {
@@ -38,6 +39,7 @@ const {
 			</div>
 		</div>
 	</section>
+  <ShowcaseBanner />
   <section class="bg-primary-focus text-primary-content">
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8 sm:py-12 xl:py-24">
       <h2 class="text-2xl sm:text-3xl font-bold sm:text-center mb-8 sm:mb-12 xl:mb-16">Get involved on</h2>

--- a/src/pages/showcase/index.astro
+++ b/src/pages/showcase/index.astro
@@ -4,6 +4,7 @@ export const prerender = true
 import Layout from '../../layouts/Layout.astro';
 import json from '../../data/showcase.json';
 import gh from 'parse-github-url';
+import ShowcaseBanner from '../../components/ShowcaseBanner.astro';
 
 const {
   title = 'Showcase',
@@ -53,6 +54,7 @@ const {
             </div>    
           ))}
         </div>
+        <ShowcaseBanner classes="mt-8" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Description

This PR adds a new `ShowcaseBanner` Astro component.

### Motivation & Context

Adding projects to the showcase page can be a great value for the community. The page being "hidden" in the footer, highlighting this feature on the homepage is important. And adding this banner is also important directly on the Showcase page itself.

### Type of changes

- New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Open-reSource/openresource.dev/blob/main/CONTRIBUTING.md)
