### PR TITLE
chore(deps): pin `@astrojs/sitemap` dep to 1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@astrojs/markdown-remark": "^2.1.4",
         "@astrojs/mdx": "^0.19.1",
         "@astrojs/rss": "^2.4.0",
-        "@astrojs/sitemap": "^1.3.0",
+        "@astrojs/sitemap": "^1.2.2",
         "@astrojs/tailwind": "^3.1.1",
         "@astrojs/vercel": "^3.2.5",
         "@vercel/analytics": "^1.0.1",
@@ -183,9 +183,9 @@
       }
     },
     "node_modules/@astrojs/sitemap": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-1.3.0.tgz",
-      "integrity": "sha512-s1/v9MfnxVLvH5v4edK02bBAOMp5tuEvhPT1pJ2qaqXM6QZuqatk/xQU3kuWebQh+yqnD2yBeeHbmfwr4gG1vw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-1.2.2.tgz",
+      "integrity": "sha512-rjgFEPzETMVYgOMECIFP2vCkwzF9nLB31/6XWN548IeU/IlFgYR28RbsGTIjUElDak/9AF3jzjtzyldAZger3Q==",
       "dependencies": {
         "sitemap": "^7.1.1",
         "zod": "^3.17.3"
@@ -15254,9 +15254,9 @@
       }
     },
     "@astrojs/sitemap": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-1.3.0.tgz",
-      "integrity": "sha512-s1/v9MfnxVLvH5v4edK02bBAOMp5tuEvhPT1pJ2qaqXM6QZuqatk/xQU3kuWebQh+yqnD2yBeeHbmfwr4gG1vw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-1.2.2.tgz",
+      "integrity": "sha512-rjgFEPzETMVYgOMECIFP2vCkwzF9nLB31/6XWN548IeU/IlFgYR28RbsGTIjUElDak/9AF3jzjtzyldAZger3Q==",
       "requires": {
         "sitemap": "^7.1.1",
         "zod": "^3.17.3"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@astrojs/markdown-remark": "^2.1.4",
     "@astrojs/mdx": "^0.19.1",
     "@astrojs/rss": "^2.4.0",
-    "@astrojs/sitemap": "^1.3.0",
+    "@astrojs/sitemap": "^1.2.2",
     "@astrojs/tailwind": "^3.1.1",
     "@astrojs/vercel": "^3.2.5",
     "@vercel/analytics": "^1.0.1",


### PR DESCRIPTION
### Related issues

https://github.com/withastro/astro/issues/7015

### Description

Observing the same issue as https://github.com/withastro/astro/issues/7015 so pinning `@astrojs/sitemap` to `1.2.2`.

### Type of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Open-reSource/openresource.dev/blob/main/CONTRIBUTING.md)
