### PR TITLE
fix(showcase): don't display 'Show projects' link

### DIFF
--- a/src/components/ShowcaseBanner.astro
+++ b/src/components/ShowcaseBanner.astro
@@ -1,5 +1,5 @@
 ---
-const { classes } = Astro.props;
+const { classes, showProjectsButton = false } = Astro.props;
 ---
 <section class={`bg-secondary-focus text-secondary-content not-prose ${classes}`}>
   <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8 sm:py-12 xl:py-24">
@@ -15,9 +15,9 @@ const { classes } = Astro.props;
           Submit your Open Source project(s), profiles or websites to the showcase and let the community discover your work.
         </p>
       </div>
-      <div class="flex flex-col xs:flex-row sm:justify-center gap-4 mt-8">
+      <div class="flex flex-col xs:flex-row justify-center gap-4 mt-8">
         <a class="btn" href="https://github.com/orgs/Open-reSource/discussions/3" target="_blank" rel="noopener">Submit project(s)</a>
-        <a class="btn btn-outline text-primary-content" href="/showcase">Show project(s)</a>
+        { showProjectsButton && (<a class="btn btn-outline text-primary-content" href="/showcase">Show projects</a>) }
       </div>
     </div>
   </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -39,7 +39,7 @@ const {
 			</div>
 		</div>
 	</section>
-  <ShowcaseBanner />
+  <ShowcaseBanner showProjectsButton="true" />
   <section class="bg-primary-focus text-primary-content">
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8 sm:py-12 xl:py-24">
       <h2 class="text-2xl sm:text-3xl font-bold sm:text-center mb-8 sm:mb-12 xl:mb-16">Get involved on</h2>


### PR DESCRIPTION
### Related issues

Closes #35

### Description

This PR:
* removes the 'Show projects' link in the /showcase page
* changes the wording since we now have multiple projects on the Showcase page
* modifies the alignment so that it's always horizontally centered whatever the breakpoint

### Type of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Open-reSource/openresource.dev/blob/main/CONTRIBUTING.md)
