### PR TITLE
chore(deps): bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "dependencies": {
         "@astrojs/markdown-remark": "^2.1.4",
         "@astrojs/mdx": "^0.19.1",
-        "@astrojs/rss": "^2.4.0",
+        "@astrojs/rss": "^2.4.1",
         "@astrojs/sitemap": "^1.2.2",
-        "@astrojs/tailwind": "^3.1.1",
-        "@astrojs/vercel": "^3.2.5",
+        "@astrojs/tailwind": "^3.1.2",
+        "@astrojs/vercel": "^3.3.0",
         "@vercel/analytics": "^1.0.1",
-        "astro": "^2.4.3",
-        "daisyui": "^2.51.5",
+        "astro": "^2.4.5",
+        "daisyui": "^2.51.6",
         "tailwindcss": "^3.3.2",
         "theme-change": "^2.5.0"
       },
@@ -174,9 +174,9 @@
       }
     },
     "node_modules/@astrojs/rss": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-2.4.0.tgz",
-      "integrity": "sha512-cbSgrNUCmwfzXTEqfK/6vk+Ut5auHnIpv6Z5e5JaiDPUX7vcn3175nFBj68ujcb5HGY0rQ9ohGY4a4VX3ScmDg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-2.4.1.tgz",
+      "integrity": "sha512-c+j6Dwxc/t50/v7xhM88RKbxh9SjaQMw0IdLeeOqQAdcLT2Me7nUUWwx0BbPnu6RO0YxT5Up1Sl/OdrA60tfSw==",
       "dependencies": {
         "fast-xml-parser": "^4.0.8",
         "kleur": "^4.1.5"
@@ -192,17 +192,17 @@
       }
     },
     "node_modules/@astrojs/tailwind": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/tailwind/-/tailwind-3.1.1.tgz",
-      "integrity": "sha512-Wx/ZtVnmtfqHWGVzvUEYZm8rufVKVgDIef0q6fzwUxoT1EpTTwBkTbpnzooogewMLOh2eTscasGe3Ih2HC1wVA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/tailwind/-/tailwind-3.1.2.tgz",
+      "integrity": "sha512-KyZ84WExLRU/TRIQm09ce+ND/0UG9AK9+7k/gjCbxuKScc/RieZ73oh4MkoEFrN/9OToMklvt+wmkAt3+u/ubQ==",
       "dependencies": {
-        "@proload/core": "^0.3.2",
-        "autoprefixer": "^10.4.7",
-        "postcss": "^8.4.14",
+        "@proload/core": "^0.3.3",
+        "autoprefixer": "^10.4.14",
+        "postcss": "^8.4.23",
         "postcss-load-config": "^4.0.1"
       },
       "peerDependencies": {
-        "astro": "^2.1.3",
+        "astro": "^2.3.3",
         "tailwindcss": "^3.0.24"
       }
     },
@@ -225,11 +225,11 @@
       }
     },
     "node_modules/@astrojs/vercel": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-3.2.5.tgz",
-      "integrity": "sha512-Az2Qcd0GSJHqZV7eWLe8q3h3tzbMApvSQbO6kCoJ9G4cUlQN1UeMZYQcJEG0WBB9YmHQNvttt8qyowVPACnwuQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-3.3.0.tgz",
+      "integrity": "sha512-OwbxRL7kw5TFVwPn18/M9Dqp14SrPlEUSqzx+7WSvID/3W/MMuiwC5Ey0CoKUVPYruXxOaacDJKa1bzNoYgV/A==",
       "dependencies": {
-        "@astrojs/webapi": "^2.1.0",
+        "@astrojs/webapi": "^2.1.1",
         "@vercel/analytics": "^0.1.8",
         "@vercel/nft": "^0.22.1",
         "fast-glob": "^3.2.11",
@@ -237,7 +237,7 @@
         "web-vitals": "^3.1.1"
       },
       "peerDependencies": {
-        "astro": "^2.3.1"
+        "astro": "^2.3.4"
       }
     },
     "node_modules/@astrojs/vercel/node_modules/@vercel/analytics": {
@@ -5175,9 +5175,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-2.4.3.tgz",
-      "integrity": "sha512-WU7sMkgFNQs4WZzEmpjOYZthcT8+LSmwIR0GvWzVYlb+dIMfFCQyg99LNHdhg/XZKi08ztaHmRf4ZBjJvZHsgA==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-2.4.5.tgz",
+      "integrity": "sha512-osxLnuLXaOX0FjWOVQH8cmK4N/Gdj/ZdEkeyMJWsUss7xQU4Q64tAxB/dAv75f/XZiu+PprmndJkyQ4sYLOv1g==",
       "dependencies": {
         "@astrojs/compiler": "^1.4.0",
         "@astrojs/language-server": "^1.0.0",
@@ -6308,9 +6308,9 @@
       "dev": true
     },
     "node_modules/daisyui": {
-      "version": "2.51.5",
-      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-2.51.5.tgz",
-      "integrity": "sha512-L05dRw0tasmz2Ha+10LhftEGLq4kaA8vRR/T0wDaXfHwqcgsf81jfXDJ6NlZ63Z7Rl1k3rj7UHs0l0p7CM3aYA==",
+      "version": "2.51.6",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-2.51.6.tgz",
+      "integrity": "sha512-JRqOKayuFCmWe4X4k6Qvx1y7V/VNao8U5eTSOhusOKIzCsYqf56+TCSe4d7zmqGE0V6JiLDYAT8JeoWUeRKFCw==",
       "dependencies": {
         "color": "^4.2",
         "css-selector-tokenizer": "^0.8.0",
@@ -15245,9 +15245,9 @@
       }
     },
     "@astrojs/rss": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-2.4.0.tgz",
-      "integrity": "sha512-cbSgrNUCmwfzXTEqfK/6vk+Ut5auHnIpv6Z5e5JaiDPUX7vcn3175nFBj68ujcb5HGY0rQ9ohGY4a4VX3ScmDg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-2.4.1.tgz",
+      "integrity": "sha512-c+j6Dwxc/t50/v7xhM88RKbxh9SjaQMw0IdLeeOqQAdcLT2Me7nUUWwx0BbPnu6RO0YxT5Up1Sl/OdrA60tfSw==",
       "requires": {
         "fast-xml-parser": "^4.0.8",
         "kleur": "^4.1.5"
@@ -15263,13 +15263,13 @@
       }
     },
     "@astrojs/tailwind": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/tailwind/-/tailwind-3.1.1.tgz",
-      "integrity": "sha512-Wx/ZtVnmtfqHWGVzvUEYZm8rufVKVgDIef0q6fzwUxoT1EpTTwBkTbpnzooogewMLOh2eTscasGe3Ih2HC1wVA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/tailwind/-/tailwind-3.1.2.tgz",
+      "integrity": "sha512-KyZ84WExLRU/TRIQm09ce+ND/0UG9AK9+7k/gjCbxuKScc/RieZ73oh4MkoEFrN/9OToMklvt+wmkAt3+u/ubQ==",
       "requires": {
-        "@proload/core": "^0.3.2",
-        "autoprefixer": "^10.4.7",
-        "postcss": "^8.4.14",
+        "@proload/core": "^0.3.3",
+        "autoprefixer": "^10.4.14",
+        "postcss": "^8.4.23",
         "postcss-load-config": "^4.0.1"
       }
     },
@@ -15289,11 +15289,11 @@
       }
     },
     "@astrojs/vercel": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-3.2.5.tgz",
-      "integrity": "sha512-Az2Qcd0GSJHqZV7eWLe8q3h3tzbMApvSQbO6kCoJ9G4cUlQN1UeMZYQcJEG0WBB9YmHQNvttt8qyowVPACnwuQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-3.3.0.tgz",
+      "integrity": "sha512-OwbxRL7kw5TFVwPn18/M9Dqp14SrPlEUSqzx+7WSvID/3W/MMuiwC5Ey0CoKUVPYruXxOaacDJKa1bzNoYgV/A==",
       "requires": {
-        "@astrojs/webapi": "^2.1.0",
+        "@astrojs/webapi": "^2.1.1",
         "@vercel/analytics": "^0.1.8",
         "@vercel/nft": "^0.22.1",
         "fast-glob": "^3.2.11",
@@ -18742,9 +18742,9 @@
       "integrity": "sha512-97a+l2LBU3Op3bBQEff79i/E4jMD2ZLFD8rHx9B6mXyB2uQwhJQYfiDqUwtfjF4QA1F2qs//N6Cw8LetMbQjcw=="
     },
     "astro": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-2.4.3.tgz",
-      "integrity": "sha512-WU7sMkgFNQs4WZzEmpjOYZthcT8+LSmwIR0GvWzVYlb+dIMfFCQyg99LNHdhg/XZKi08ztaHmRf4ZBjJvZHsgA==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-2.4.5.tgz",
+      "integrity": "sha512-osxLnuLXaOX0FjWOVQH8cmK4N/Gdj/ZdEkeyMJWsUss7xQU4Q64tAxB/dAv75f/XZiu+PprmndJkyQ4sYLOv1g==",
       "requires": {
         "@astrojs/compiler": "^1.4.0",
         "@astrojs/language-server": "^1.0.0",
@@ -19558,9 +19558,9 @@
       "dev": true
     },
     "daisyui": {
-      "version": "2.51.5",
-      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-2.51.5.tgz",
-      "integrity": "sha512-L05dRw0tasmz2Ha+10LhftEGLq4kaA8vRR/T0wDaXfHwqcgsf81jfXDJ6NlZ63Z7Rl1k3rj7UHs0l0p7CM3aYA==",
+      "version": "2.51.6",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-2.51.6.tgz",
+      "integrity": "sha512-JRqOKayuFCmWe4X4k6Qvx1y7V/VNao8U5eTSOhusOKIzCsYqf56+TCSe4d7zmqGE0V6JiLDYAT8JeoWUeRKFCw==",
       "requires": {
         "color": "^4.2",
         "css-selector-tokenizer": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
   "dependencies": {
     "@astrojs/markdown-remark": "^2.1.4",
     "@astrojs/mdx": "^0.19.1",
-    "@astrojs/rss": "^2.4.0",
+    "@astrojs/rss": "^2.4.1",
     "@astrojs/sitemap": "^1.2.2",
-    "@astrojs/tailwind": "^3.1.1",
-    "@astrojs/vercel": "^3.2.5",
+    "@astrojs/tailwind": "^3.1.2",
+    "@astrojs/vercel": "^3.3.0",
     "@vercel/analytics": "^1.0.1",
-    "astro": "^2.4.3",
-    "daisyui": "^2.51.5",
+    "astro": "^2.4.5",
+    "daisyui": "^2.51.6",
     "tailwindcss": "^3.3.2",
     "theme-change": "^2.5.0"
   },


### PR DESCRIPTION
### Description

Bump dependencies listed by Dependabot:
- `@astrojs/rss`: `^2.4.0` → `^2.4.1`
- `@astrojs/tailwind`: `^3.1.1` → `^3.1.2`
- `@astrojs/vercel`: `^3.2.5` → `^3.3.0`
- `astro`: `^2.4.3` → `^2.4.5`
- `daisyui`: `^2.51.5` → `^2.51.6`


### Type of changes

- Chore (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Open-reSource/openresource.dev/blob/main/CONTRIBUTING.md)
