### PR TITLE
feat: add progress scroll to articles and chapters

### DIFF
--- a/src/components/ProgressScroll.astro
+++ b/src/components/ProgressScroll.astro
@@ -6,9 +6,11 @@
 
 <script>
   window.addEventListener('scroll', function() {
-    var scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-    var scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
-    var progress = (scrollTop / scrollHeight) * 100;
-    document.getElementById('progress-scroll').style.width = progress + '%';
+    if (document && document.getElementById('progress-scroll')) {
+      var scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+      var scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
+      var progress = (scrollTop / scrollHeight) * 100;
+      document.getElementById('progress-scroll').style.width = progress + '%';
+    }
   });
 </script>

--- a/src/components/ProgressScroll.astro
+++ b/src/components/ProgressScroll.astro
@@ -1,0 +1,14 @@
+---
+---
+<div class="fixed top-0 h-1.5 w-full bg-transparent" aria-hidden="true">
+  <div id="progress-scroll" class="h-full w-0 bg-primary transition ease-in-out delay-300 opacity-100"></div>
+</div>
+
+<script>
+  window.addEventListener('scroll', function() {
+    var scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+    var scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
+    var progress = (scrollTop / scrollHeight) * 100;
+    document.getElementById('progress-scroll').style.width = progress + '%';
+  });
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,14 +2,16 @@
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import '../global.css';
+import ProgressScroll from '../components/ProgressScroll.astro';
 
 export interface Props {
 	description: string;
 	home?: boolean;
 	title: string;
+  progressScroll?: boolean;
 }
 
-const { home = false, title, description } = Astro.props;
+const { home = false, title, description, progressScroll = false } = Astro.props;
 ---
 
 <!DOCTYPE html>
@@ -48,6 +50,7 @@ const { home = false, title, description } = Astro.props;
 			<slot />
 		</main>
 		<Footer divider={ !home } />
+    { progressScroll && <ProgressScroll /> }
 	</body>
 </html>
 <script>

--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -15,7 +15,7 @@ export async function getStaticPaths() {
 const { entry } = Astro.props;
 const { Content } = await entry.render();
 ---
-<Layout title={entry.data.title} description={entry.data.description}>
+<Layout title={entry.data.title} description={entry.data.description} progressScroll={true}>
   <div class="bg-base-100 py-8 flex flex-col justify-center relative overflow-hidden lg:py-12">
     <div class="relative w-full px-6 py-12 bg-base-100 shadow-xl shadow-base-300 ring-1 ring-base-200 md:max-w-3xl md:mx-auto lg:max-w-4xl lg:pt-16 lg:pb-28">
       <div class="mt-8 prose prose-slate mx-auto lg:prose-lg">

--- a/src/pages/guide/[...slug].astro
+++ b/src/pages/guide/[...slug].astro
@@ -85,7 +85,7 @@ const { Content } = await entry.render();
 )}
 
 { !isIndex && (
-<Layout title={ entry.data.title } description={ entry.data.metaDescription }>
+<Layout title={ entry.data.title } description={ entry.data.metaDescription } progressScroll={true}>
   <div class="text-sm breadcrumbs pb-8">
     <ul>
       <li><a href="/guide">Guide</a></li>


### PR DESCRIPTION
### Description

This PR adds a visual progress bar on top of the website for articles and chapters to see the reading progress. It uses the percentage of the page scrolled.

Technically, my first idea is that this information is not really helpful for screen readers. But if I'm mistaken in the future based on user feedback, it can be revisited later.

### Motivation & Context

Small nice indicator.

### Type of changes

- New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Open-reSource/openresource.dev/blob/main/CONTRIBUTING.md)
