### PR TITLE
fix: issue form description brand name consistency

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Report a bug
-description: Tell us about a bug or issue you may have identified in openresource.dev.
+description: Tell us about a bug or issue you may have identified in Open {re}Source.
 title: "Provide a general summary of the issue"
 labels: [bug]
 assignees: "-"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: Suggest new or updated features to include in openresource.dev.
+description: Suggest new or updated features to include in Open {re}Source.
 title: "Suggest a new feature"
 labels: [feature]
 assignees: []


### PR DESCRIPTION
### Related issues

I did not bother creating an issue for this considering the simplicity of the change.

### Description

While working on an [issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms) related tool and testing it against various issue forms from various repositories, I noticed that the brand name of the project is not consistent across the issue forms descriptions.

<img width="1176" alt="Screenshot 2023-05-17 at 16 58 00" src="https://github.com/Open-reSource/openresource.dev/assets/494699/c7e5e4bf-0a71-4026-b65d-780f93c2eed6">

This pull request aims to fix this inconsistency by replacing the brand name with the one always used in the website, `Open {re}Source`.

### Motivation & Context

This solves nothing.

### Type of changes

- N/A

### Checklist

- [X] I have read the [contributing guidelines](https://github.com/Open-reSource/openresource.dev/blob/main/CONTRIBUTING.md)