### PR TITLE
fix(css): drop clipboard copy area bg color and align top copy btn

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -46,7 +46,7 @@ main {
 }
 
 .clipboard-copy {
-  background-color: #0d1117;
+  background-color: #24292e;
 }
 
 .astro-code {


### PR DESCRIPTION
### Description

The clipboard area rendering is not nice. Almost black color looks weird and makes feel the corner buggy.

![Screenshot 2023-05-19 at 13 16 47](https://github.com/Open-reSource/openresource.dev/assets/17381666/0e4290c9-67d9-4d4a-ab10-53314fdf5b09)
![Screenshot 2023-05-19 at 13 16 54](https://github.com/Open-reSource/openresource.dev/assets/17381666/71f26789-cebf-461e-a56e-a9cf45c42129)

It wasn't the case before. Maybe the background color has changed while updating Astro 🤷 

Anyway, this PR changes the hexadecimal value to retrieve the same one as the code background.

Tested with several themes in combination with OS settings (dark & light mode); the color always remains the same.

### Type of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Open-reSource/openresource.dev/blob/main/CONTRIBUTING.md)
