### PR TITLE
feat(license): change licensing to CC BY-NC-SA 4.0 for articles and guide content

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Good pull requests—patches, improvements, new features—are a fantastic help.
 
 **Do not create a Pull Request with new content.** New content in the guide (modules or chapters) or in the articles are provided only by the core team.
 
-**However**, if existing content can be improved, Pull Requests are welcome! Notice that in this case, this work is going to be licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+**However**, if existing content can be improved, Pull Requests are welcome! Notice that in this case, this work is going to be licensed under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).
 
 Adhering to the following process is the best way to get your work included in the project:
 
@@ -118,9 +118,9 @@ Adhering to the following process is the best way to get your work included in t
 
 7. [Open a Pull Request](https://help.github.com/articles/about-pull-requests/) with a clear title and description against the `main` branch.
 
-**IMPORTANT**: By submitting a patch, you agree to allow the project owners to license your work under the terms of the [MIT License](../LICENSE) (if it includes code changes) and under the terms of the [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) (if it includes content changes).
+**IMPORTANT**: By submitting a patch, you agree to allow the project owners to license your work under the terms of the [MIT License](../LICENSE) (if it includes code changes) and under the terms of the [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) (if it includes content changes).
 
 ## License
 
 By contributing your code, you agree to license your contribution under the [MIT License](../LICENSE).
-By contributing to the documentation, you agree to license your contribution under the [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+By contributing to the documentation, you agree to license your contribution under the [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).

--- a/LICENSE
+++ b/LICENSE
@@ -23,6 +23,6 @@ SOFTWARE.
 ---
 
 Code released under the MIT License.
-Content (including images) released under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/):
+Content (including images) released under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/):
 * `public/images/` directory
 * `src/content/articles` and `src/content/modules` directories

--- a/README.md
+++ b/README.md
@@ -62,6 +62,6 @@ Get update on Open {re}Source's development and chat with the project maintainer
 
 Code released under the [MIT License](https://github.com/Open-reSource/openresource.dev/blob/main/LICENSE).
 
-Content (including images) released under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/):
+Content (including images) released under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/):
 * `public/images/` directory
 * `src/content/articles` and `src/content/modules` directories

--- a/src/components/CreativeCommonMention.astro
+++ b/src/components/CreativeCommonMention.astro
@@ -1,0 +1,5 @@
+---
+---
+<p class="text-sm not-prose">
+  <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank" rel="noopener" class="underline">CC BY-NC-SA 4.0</a> 2023 © Open &lcub;re&rcub;Source
+</p>

--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -4,6 +4,7 @@ import Layout from '../../layouts/Layout.astro';
 import readingTime from 'reading-time';
 import { getCollection } from 'astro:content';
 import Feedback from '../../components/Feedback.astro';
+import CreativeCommonMention from '../../components/CreativeCommonMention.astro';
 
 export async function getStaticPaths() {
   const blogEntries = await getCollection('articles');
@@ -34,6 +35,7 @@ const { Content } = await entry.render();
         <Content />
         <hr>
         <Feedback id={entry.id} type="articles" />
+        <CreativeCommonMention />
       </div>
     </div>
   </div>

--- a/src/pages/guide/[...slug].astro
+++ b/src/pages/guide/[...slug].astro
@@ -4,6 +4,7 @@ import Layout from '../../layouts/Layout.astro';
 import readingTime from 'reading-time';
 import { getCollection } from 'astro:content';
 import Feedback from '../../components/Feedback.astro';
+import CreativeCommonMention from '../../components/CreativeCommonMention.astro';
 
 export async function getStaticPaths() {
   const modulesEntries = await getCollection('modules', ({ data }) => {
@@ -109,6 +110,7 @@ const { Content } = await entry.render();
           <Content />
           <hr>
           <Feedback id={entry.id} type="modules" />
+          <CreativeCommonMention />
           <div class="flex flex-col xs:flex-row justify-center gap-5 sm:mt-32 items-center mt-16">
             {
               entry.data.id > 1 && (


### PR DESCRIPTION
### Description

This PR changes the license of the content of this repository from CC BY 4.0 to CC BY-NC-SA 4.0. It is still possible to change it since no content has been created or modified yet by external contributors.

It is reflected obviously in the `LICENSE` file, but also in the `README.md` file and in the `CONTRIBUTING.md` file.

This PR also displays this license in the footer of articles and guide chapters so that it is clear also for users/readers. In order to do so, a new Astro component named `CreativeCommonMention.astro` has been created.

### Type of changes

- New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Open-reSource/openresource.dev/blob/main/CONTRIBUTING.md)
