### PR TITLE
chore(deps): bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,14 +7,14 @@
     "": {
       "version": "0.0.1",
       "dependencies": {
-        "@astrojs/markdown-remark": "^2.1.4",
-        "@astrojs/mdx": "^0.19.1",
-        "@astrojs/rss": "^2.4.1",
-        "@astrojs/sitemap": "^1.2.2",
-        "@astrojs/tailwind": "^3.1.2",
-        "@astrojs/vercel": "^3.3.0",
+        "@astrojs/markdown-remark": "^2.2.1",
+        "@astrojs/mdx": "^0.19.3",
+        "@astrojs/rss": "^2.4.3",
+        "@astrojs/sitemap": "^1.3.1",
+        "@astrojs/tailwind": "^3.1.3",
+        "@astrojs/vercel": "^3.4.0",
         "@vercel/analytics": "^1.0.1",
-        "astro": "^2.4.5",
+        "astro": "^2.5.3",
         "daisyui": "^2.51.6",
         "tailwindcss": "^3.3.2",
         "theme-change": "^2.5.0"
@@ -28,7 +28,7 @@
         "parse-github-url": "^1.0.2",
         "reading-time": "^1.5.0",
         "rehype-autolink-headings": "^6.1.1",
-        "vercel": "^29.3.6"
+        "vercel": "^29.4.0"
       }
     },
     "node_modules/@actions/core": {
@@ -102,11 +102,11 @@
       }
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-2.2.0.tgz",
-      "integrity": "sha512-4M1+GzQwDqF0KfX9Ahug43b0avorcK+iTapEaVuNnaCUVS6sZKRkztT3g6hmXiFmGHSL8qYaS9IVEmKtP6hYmw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-2.2.1.tgz",
+      "integrity": "sha512-VF0HRv4GpC1XEMLnsKf6jth7JSmlt9qpqP0josQgA2eSpCIAC/Et+y94mgdBIZVBYH/yFnMoIxgKVe93xfO2GA==",
       "dependencies": {
-        "@astrojs/prism": "^2.1.0",
+        "@astrojs/prism": "^2.1.2",
         "github-slugger": "^1.4.0",
         "import-meta-resolve": "^2.1.0",
         "rehype-raw": "^6.1.1",
@@ -121,7 +121,7 @@
         "vfile": "^5.3.2"
       },
       "peerDependencies": {
-        "astro": "^2.4.0"
+        "astro": "^2.5.0"
       }
     },
     "node_modules/@astrojs/markdown-remark/node_modules/github-slugger": {
@@ -130,12 +130,12 @@
       "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw=="
     },
     "node_modules/@astrojs/mdx": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-0.19.1.tgz",
-      "integrity": "sha512-9GNNZbGT+lGvbRkQK/NaEJcnjj1T94/ne0KwPjJgNCBQrJuskX5IW1hKiE5bRSOFvkAOrBGneYKg0GXYArBOQQ==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-0.19.3.tgz",
+      "integrity": "sha512-XiIQRO1OlJ19jqaZuttt6TSvnEIIiOVkHiNXPCOOsHnRpbLFuv0y0FoFuhYYRTHHm4rfSV2BRP5INiD5Aq9ByA==",
       "dependencies": {
-        "@astrojs/markdown-remark": "^2.2.0",
-        "@astrojs/prism": "^2.1.1",
+        "@astrojs/markdown-remark": "^2.2.1",
+        "@astrojs/prism": "^2.1.2",
         "@mdx-js/mdx": "^2.3.0",
         "@mdx-js/rollup": "^2.3.0",
         "acorn": "^8.8.0",
@@ -163,9 +163,9 @@
       "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw=="
     },
     "node_modules/@astrojs/prism": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-2.1.1.tgz",
-      "integrity": "sha512-Gnwnlb1lGJzCQEg89r4/WqgfCGPNFC7Kuh2D/k289Cbdi/2PD7Lrdstz86y1itDvcb2ijiRqjqWnJ5rsfu/QOA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-2.1.2.tgz",
+      "integrity": "sha512-3antim1gb34689GHRQFJ88JEo93HuZKQBnmxDT5W/nxiNz1p/iRxnCTEhIbJhqMOTRbbo5h2ldm5qSxx+TMFQA==",
       "dependencies": {
         "prismjs": "^1.28.0"
       },
@@ -174,27 +174,27 @@
       }
     },
     "node_modules/@astrojs/rss": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-2.4.1.tgz",
-      "integrity": "sha512-c+j6Dwxc/t50/v7xhM88RKbxh9SjaQMw0IdLeeOqQAdcLT2Me7nUUWwx0BbPnu6RO0YxT5Up1Sl/OdrA60tfSw==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-2.4.3.tgz",
+      "integrity": "sha512-Dc8lxsXiDlnxONVIUuc3ohO1+vV1Hp9fRFdUianOola0S9/xv/6FzIHhkQ62MkaFSlcZm5uIOllRWNKVvuFuoA==",
       "dependencies": {
         "fast-xml-parser": "^4.0.8",
         "kleur": "^4.1.5"
       }
     },
     "node_modules/@astrojs/sitemap": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-1.2.2.tgz",
-      "integrity": "sha512-rjgFEPzETMVYgOMECIFP2vCkwzF9nLB31/6XWN548IeU/IlFgYR28RbsGTIjUElDak/9AF3jzjtzyldAZger3Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-1.3.1.tgz",
+      "integrity": "sha512-4ZBug4ml+2Nl5/Uh4VSja8Kij/DU7/RaNMciXCNm1EzQkP/jm+nqMG1liDDcQK5zXPAoLeaat06IbhNlruvQjg==",
       "dependencies": {
         "sitemap": "^7.1.1",
         "zod": "^3.17.3"
       }
     },
     "node_modules/@astrojs/tailwind": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/tailwind/-/tailwind-3.1.2.tgz",
-      "integrity": "sha512-KyZ84WExLRU/TRIQm09ce+ND/0UG9AK9+7k/gjCbxuKScc/RieZ73oh4MkoEFrN/9OToMklvt+wmkAt3+u/ubQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/tailwind/-/tailwind-3.1.3.tgz",
+      "integrity": "sha512-10S1omrv5K5HRVAZ0fBgN5vQykn2HRL332LAVFyBASMn1Ff6gDfSK+CPUeUu94eZUOEaPnECLK8EHAqZ8iY9CA==",
       "dependencies": {
         "@proload/core": "^0.3.3",
         "autoprefixer": "^10.4.14",
@@ -202,7 +202,7 @@
         "postcss-load-config": "^4.0.1"
       },
       "peerDependencies": {
-        "astro": "^2.3.3",
+        "astro": "^2.5.0",
         "tailwindcss": "^3.0.24"
       }
     },
@@ -225,19 +225,20 @@
       }
     },
     "node_modules/@astrojs/vercel": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-3.3.0.tgz",
-      "integrity": "sha512-OwbxRL7kw5TFVwPn18/M9Dqp14SrPlEUSqzx+7WSvID/3W/MMuiwC5Ey0CoKUVPYruXxOaacDJKa1bzNoYgV/A==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-3.4.0.tgz",
+      "integrity": "sha512-pTD7PUos5uoUFZZXooiNN2vcALLQtGF1urtaFCEMWJVbmpYUC8YlA8RsISbF2ICEpTgDWMHttRJE10aCBHrmKA==",
       "dependencies": {
         "@astrojs/webapi": "^2.1.1",
         "@vercel/analytics": "^0.1.8",
         "@vercel/nft": "^0.22.1",
+        "esbuild": "^0.17.12",
         "fast-glob": "^3.2.11",
         "set-cookie-parser": "^2.5.1",
         "web-vitals": "^3.1.1"
       },
       "peerDependencies": {
-        "astro": "^2.3.4"
+        "astro": "^2.5.0"
       }
     },
     "node_modules/@astrojs/vercel/node_modules/@vercel/analytics": {
@@ -2035,9 +2036,9 @@
       "dev": true
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.13.tgz",
-      "integrity": "sha512-5tZZ/hLIfBmt7E8JsE5KbsknoAFmoElkg+A/gjyPtmSQvJjPf+9GsSJihid8VMa08lrsYyaEXOT9RLh3xXQONw==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
       "cpu": [
         "arm"
       ],
@@ -2050,9 +2051,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.13.tgz",
-      "integrity": "sha512-F5DgvJMV2ZEpLNpPCO7FEk1wy8O5tg6cikWSB6uvvncsgE1xgbPlm+Boio/4820C2/mj713X83X1h01v0qoeHg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
       "cpu": [
         "arm64"
       ],
@@ -2065,9 +2066,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.13.tgz",
-      "integrity": "sha512-5m1UUslzpfVrumG3m3Zv2x9VNAcvMOQWJy009y6jt10tcHpzIq2/b0I0k4fz0QYqGSNS1GteRIhVPN4H7OyCXg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
       "cpu": [
         "x64"
       ],
@@ -2080,9 +2081,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.13.tgz",
-      "integrity": "sha512-TXbXp/05r7heRsG8yWwbHw9diay+wXIyRNcIHFoNARRIGahYbTW/qwJzE37zkfxLIUPHgR/SyLTUlnTICg14ag==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
       "cpu": [
         "arm64"
       ],
@@ -2095,9 +2096,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.13.tgz",
-      "integrity": "sha512-Ku9Db2sblCxFvQdEO7X9nBaLR/S81uch81e2Q2+Os5z1NcnsFjuqhIYH0Gm6KNNpIKaEbC7gCLbiIPbLLMX4Pg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
       "cpu": [
         "x64"
       ],
@@ -2110,9 +2111,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.13.tgz",
-      "integrity": "sha512-t1T5/nIf2j+FdSf1Fa3dcU0cXycr0nK4xJe52qjWa+1I249mM5NBY1ODjiabZxZ0x3CG05y4fd9bxfDLy9kQtA==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
       "cpu": [
         "arm64"
       ],
@@ -2125,9 +2126,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.13.tgz",
-      "integrity": "sha512-/zbkgEO4gY2qGZr9UNAGI38w/FwUY4bx4EC88k9VeiCKNr3ukNgwH/oIgB5Z9/OqpkNLlcS4w9e2d/MIiy5fbw==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
       "cpu": [
         "x64"
       ],
@@ -2140,9 +2141,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.13.tgz",
-      "integrity": "sha512-RrhjzrCF6aCDH248nUAQoldnRmN7nHMxv85GOj5AH+qkxxYvcig7fnUmgANngntRu4btXhN9WKHMgQ5seERDMw==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
       "cpu": [
         "arm"
       ],
@@ -2155,9 +2156,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.13.tgz",
-      "integrity": "sha512-siu3QZrQ7eGrSttvFaRKyjT7kNRbUuHEKzCCyqRh19MbpGokGY13jbIsBEjx6JmH3T50hds325oweS9Ey2ihAQ==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
       "cpu": [
         "arm64"
       ],
@@ -2170,9 +2171,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.13.tgz",
-      "integrity": "sha512-ADHA1PqP5gIegehVP0RvxMmNPxpLgetI8QCwYOjUheGXKIKWSdUN8ZS3rusQv3NGZmFCpYdMZzFoI0QtzzGAdw==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
       "cpu": [
         "ia32"
       ],
@@ -2185,9 +2186,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.13.tgz",
-      "integrity": "sha512-n1JQPxETmR0brkpWlJHeohReEPLH+m00bnJdNnFyHN3zLBt1QypevuZSmnmFWsC+7r7HTwWILj3lBDjtPH3ydg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
       "cpu": [
         "loong64"
       ],
@@ -2200,9 +2201,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.13.tgz",
-      "integrity": "sha512-d0pnD/j5KKQ43xtSIvOD+wNIy6D/Vh9GbXVRa3u4zCyiJMYWjxkPkbBzlEgNjdDmUM+5gBFen9k7B8Xscy+Myg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
       "cpu": [
         "mips64el"
       ],
@@ -2215,9 +2216,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.13.tgz",
-      "integrity": "sha512-C9sMpa/VcGLjVtsT01sXtzZNS7bAZ+icUclkKkiUwBQ9hzT+J+/Xpj+EykI5hB3KgtxQVo4XUahanFoZNxbQ1g==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
       "cpu": [
         "ppc64"
       ],
@@ -2230,9 +2231,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.13.tgz",
-      "integrity": "sha512-jYkc5EpNpvjccAHNYekiAtklusVGWftR0VVLtng7dJzDyy+5adAsf1fOG3LllP0WALxS55/w6boLE/728J/bXw==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
       "cpu": [
         "riscv64"
       ],
@@ -2245,9 +2246,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.13.tgz",
-      "integrity": "sha512-4jAJI5O6E/hATL4lsrG2A+noDjZ377KlATVFKwV3SWaNHj+OvoXe/T84ScQIXEtPI7ndJyLkMYruXj8RR5Ilyw==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
       "cpu": [
         "s390x"
       ],
@@ -2260,9 +2261,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.13.tgz",
-      "integrity": "sha512-eFLQhJq98qijGRcv9je/9M4Mz1suZ+pOtj62ArsLd0gubNGhhQDz6T30X2X3f1KZ8lkKkr+zN5vtZzx1GAMoFw==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
       "cpu": [
         "x64"
       ],
@@ -2275,9 +2276,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.13.tgz",
-      "integrity": "sha512-F8PXDeT+3eQpPjf4bmNJapPLu0SKKlWRGPQvBQqVS+YDGoMKnyyYp2UENLFMV8zT7kS39zKxZRZvUL3fMz/7Ww==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
       "cpu": [
         "x64"
       ],
@@ -2290,9 +2291,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.13.tgz",
-      "integrity": "sha512-9jWfzbFCnIZdHjNs+00KQHArUbp7kjQDNmiuqkwGOQFs67m4/dKNupBv2DP5hTqVlQY4tW4RG3qpb6Y3zOHJeA==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
       "cpu": [
         "x64"
       ],
@@ -2305,9 +2306,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.13.tgz",
-      "integrity": "sha512-ALbOMlTIBkAVi6KqYjONa7u2oH95RN7OpetFqMtjufFLBiSaayRuwUzhs2yuR9CfGT4qi0jv6HQDav+EG314TQ==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
       "cpu": [
         "x64"
       ],
@@ -2320,9 +2321,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.13.tgz",
-      "integrity": "sha512-FJBLYL4PkrZGeuHzEqme+0DjNetxkJ+XbB+Aoeow7aQ53JCwsA0/mo8sS5aPkDHgCnMkN4A5GLoFTlDj3BKDrQ==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
       "cpu": [
         "arm64"
       ],
@@ -2335,9 +2336,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.13.tgz",
-      "integrity": "sha512-Qrvst9RkLz4qgi3hqswNliYuKW92/HGJnd7xLWkGaGPa8S4qsONf81FW0ebDc5iUHb0I7QJwQATutvghTabnFA==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
       "cpu": [
         "ia32"
       ],
@@ -2350,9 +2351,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.13.tgz",
-      "integrity": "sha512-pZ/NIgz861XaUPlIkPFjP55nJ4PJa0o/CD4zgeRb1Q9FVE+8GvdB6ifJcK05jRhny5hKExhnRFIdgHmmCYH8vg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
       "cpu": [
         "x64"
       ],
@@ -5147,13 +5148,13 @@
       }
     },
     "node_modules/astro": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-2.4.5.tgz",
-      "integrity": "sha512-osxLnuLXaOX0FjWOVQH8cmK4N/Gdj/ZdEkeyMJWsUss7xQU4Q64tAxB/dAv75f/XZiu+PprmndJkyQ4sYLOv1g==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-2.5.3.tgz",
+      "integrity": "sha512-ZRk599V3f2dAW2+WIEi1eAhHaxqxYsp2VAAhcUp103OEw8UZIeEa7KU1xZ+cKDqaBszSnTs38EdLjwHWWXCqMw==",
       "dependencies": {
         "@astrojs/compiler": "^1.4.0",
         "@astrojs/language-server": "^1.0.0",
-        "@astrojs/markdown-remark": "^2.2.0",
+        "@astrojs/markdown-remark": "^2.2.1",
         "@astrojs/telemetry": "^2.1.1",
         "@astrojs/webapi": "^2.1.1",
         "@babel/core": "^7.18.2",
@@ -5175,12 +5176,14 @@
         "devalue": "^4.2.0",
         "diff": "^5.1.0",
         "es-module-lexer": "^1.1.0",
+        "esbuild": "^0.17.18",
         "estree-walker": "3.0.0",
         "execa": "^6.1.0",
         "fast-glob": "^3.2.11",
         "github-slugger": "^2.0.0",
         "gray-matter": "^4.0.3",
         "html-escaper": "^3.0.3",
+        "js-yaml": "^4.1.0",
         "kleur": "^4.1.4",
         "magic-string": "^0.27.0",
         "mime": "^3.0.0",
@@ -5221,10 +5224,26 @@
         }
       }
     },
+    "node_modules/astro/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
     "node_modules/astro/node_modules/estree-walker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.0.tgz",
       "integrity": "sha512-s6ceX0NFiU/vKPiKvFdR83U1Zffu7upwZsGwpoqfg5rbbq1l50WQ5hCeIvM6E6oD4shUHCYMsiFPns4Jk0YfMQ=="
+    },
+    "node_modules/astro/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/async-listen": {
       "version": "3.0.0",
@@ -6866,9 +6885,9 @@
       "integrity": "sha512-2BMfqBDeVCcOlLaL1ZAfp+D868SczNpKArrTM3dhpd7dK/OVlogzY15qpUngt+LMTq5UC/csb9vVQAgupucSbA=="
     },
     "node_modules/esbuild": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.13.tgz",
-      "integrity": "sha512-4ixMwdErBcQHgTBeoxnowENCPKWFAGxgTyKHMK8gqn9sZaC7ZNWFKtim16g2rzQ2b/FYyy3lIUUJboFtjolhqg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -6877,28 +6896,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.17.13",
-        "@esbuild/android-arm64": "0.17.13",
-        "@esbuild/android-x64": "0.17.13",
-        "@esbuild/darwin-arm64": "0.17.13",
-        "@esbuild/darwin-x64": "0.17.13",
-        "@esbuild/freebsd-arm64": "0.17.13",
-        "@esbuild/freebsd-x64": "0.17.13",
-        "@esbuild/linux-arm": "0.17.13",
-        "@esbuild/linux-arm64": "0.17.13",
-        "@esbuild/linux-ia32": "0.17.13",
-        "@esbuild/linux-loong64": "0.17.13",
-        "@esbuild/linux-mips64el": "0.17.13",
-        "@esbuild/linux-ppc64": "0.17.13",
-        "@esbuild/linux-riscv64": "0.17.13",
-        "@esbuild/linux-s390x": "0.17.13",
-        "@esbuild/linux-x64": "0.17.13",
-        "@esbuild/netbsd-x64": "0.17.13",
-        "@esbuild/openbsd-x64": "0.17.13",
-        "@esbuild/sunos-x64": "0.17.13",
-        "@esbuild/win32-arm64": "0.17.13",
-        "@esbuild/win32-ia32": "0.17.13",
-        "@esbuild/win32-x64": "0.17.13"
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
       }
     },
     "node_modules/esbuild-android-64": {
@@ -14439,9 +14458,9 @@
       }
     },
     "node_modules/vercel": {
-      "version": "29.3.6",
-      "resolved": "https://registry.npmjs.org/vercel/-/vercel-29.3.6.tgz",
-      "integrity": "sha512-fwld21d9WoCTUJcbyTWvq0c9VchUCJ2qs0kaczcYo9Vs8+ORnxC8FFgbysR2f7B4iwL2hUxTMEWkQGV2782LjQ==",
+      "version": "29.4.0",
+      "resolved": "https://registry.npmjs.org/vercel/-/vercel-29.4.0.tgz",
+      "integrity": "sha512-sVfg87dhF3q6Nhrr5zv2oaOU1zQQd+MlsjhdNkB9MfrQyXqluAdHKiNz0+g/+wJeh/y7sUhWk2/XJb5CDlF70w==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -15115,11 +15134,11 @@
       }
     },
     "@astrojs/markdown-remark": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-2.2.0.tgz",
-      "integrity": "sha512-4M1+GzQwDqF0KfX9Ahug43b0avorcK+iTapEaVuNnaCUVS6sZKRkztT3g6hmXiFmGHSL8qYaS9IVEmKtP6hYmw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-2.2.1.tgz",
+      "integrity": "sha512-VF0HRv4GpC1XEMLnsKf6jth7JSmlt9qpqP0josQgA2eSpCIAC/Et+y94mgdBIZVBYH/yFnMoIxgKVe93xfO2GA==",
       "requires": {
-        "@astrojs/prism": "^2.1.0",
+        "@astrojs/prism": "^2.1.2",
         "github-slugger": "^1.4.0",
         "import-meta-resolve": "^2.1.0",
         "rehype-raw": "^6.1.1",
@@ -15142,12 +15161,12 @@
       }
     },
     "@astrojs/mdx": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-0.19.1.tgz",
-      "integrity": "sha512-9GNNZbGT+lGvbRkQK/NaEJcnjj1T94/ne0KwPjJgNCBQrJuskX5IW1hKiE5bRSOFvkAOrBGneYKg0GXYArBOQQ==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-0.19.3.tgz",
+      "integrity": "sha512-XiIQRO1OlJ19jqaZuttt6TSvnEIIiOVkHiNXPCOOsHnRpbLFuv0y0FoFuhYYRTHHm4rfSV2BRP5INiD5Aq9ByA==",
       "requires": {
-        "@astrojs/markdown-remark": "^2.2.0",
-        "@astrojs/prism": "^2.1.1",
+        "@astrojs/markdown-remark": "^2.2.1",
+        "@astrojs/prism": "^2.1.2",
         "@mdx-js/mdx": "^2.3.0",
         "@mdx-js/rollup": "^2.3.0",
         "acorn": "^8.8.0",
@@ -15174,35 +15193,35 @@
       }
     },
     "@astrojs/prism": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-2.1.1.tgz",
-      "integrity": "sha512-Gnwnlb1lGJzCQEg89r4/WqgfCGPNFC7Kuh2D/k289Cbdi/2PD7Lrdstz86y1itDvcb2ijiRqjqWnJ5rsfu/QOA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-2.1.2.tgz",
+      "integrity": "sha512-3antim1gb34689GHRQFJ88JEo93HuZKQBnmxDT5W/nxiNz1p/iRxnCTEhIbJhqMOTRbbo5h2ldm5qSxx+TMFQA==",
       "requires": {
         "prismjs": "^1.28.0"
       }
     },
     "@astrojs/rss": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-2.4.1.tgz",
-      "integrity": "sha512-c+j6Dwxc/t50/v7xhM88RKbxh9SjaQMw0IdLeeOqQAdcLT2Me7nUUWwx0BbPnu6RO0YxT5Up1Sl/OdrA60tfSw==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-2.4.3.tgz",
+      "integrity": "sha512-Dc8lxsXiDlnxONVIUuc3ohO1+vV1Hp9fRFdUianOola0S9/xv/6FzIHhkQ62MkaFSlcZm5uIOllRWNKVvuFuoA==",
       "requires": {
         "fast-xml-parser": "^4.0.8",
         "kleur": "^4.1.5"
       }
     },
     "@astrojs/sitemap": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-1.2.2.tgz",
-      "integrity": "sha512-rjgFEPzETMVYgOMECIFP2vCkwzF9nLB31/6XWN548IeU/IlFgYR28RbsGTIjUElDak/9AF3jzjtzyldAZger3Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-1.3.1.tgz",
+      "integrity": "sha512-4ZBug4ml+2Nl5/Uh4VSja8Kij/DU7/RaNMciXCNm1EzQkP/jm+nqMG1liDDcQK5zXPAoLeaat06IbhNlruvQjg==",
       "requires": {
         "sitemap": "^7.1.1",
         "zod": "^3.17.3"
       }
     },
     "@astrojs/tailwind": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/tailwind/-/tailwind-3.1.2.tgz",
-      "integrity": "sha512-KyZ84WExLRU/TRIQm09ce+ND/0UG9AK9+7k/gjCbxuKScc/RieZ73oh4MkoEFrN/9OToMklvt+wmkAt3+u/ubQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/tailwind/-/tailwind-3.1.3.tgz",
+      "integrity": "sha512-10S1omrv5K5HRVAZ0fBgN5vQykn2HRL332LAVFyBASMn1Ff6gDfSK+CPUeUu94eZUOEaPnECLK8EHAqZ8iY9CA==",
       "requires": {
         "@proload/core": "^0.3.3",
         "autoprefixer": "^10.4.14",
@@ -15226,13 +15245,14 @@
       }
     },
     "@astrojs/vercel": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-3.3.0.tgz",
-      "integrity": "sha512-OwbxRL7kw5TFVwPn18/M9Dqp14SrPlEUSqzx+7WSvID/3W/MMuiwC5Ey0CoKUVPYruXxOaacDJKa1bzNoYgV/A==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-3.4.0.tgz",
+      "integrity": "sha512-pTD7PUos5uoUFZZXooiNN2vcALLQtGF1urtaFCEMWJVbmpYUC8YlA8RsISbF2ICEpTgDWMHttRJE10aCBHrmKA==",
       "requires": {
         "@astrojs/webapi": "^2.1.1",
         "@vercel/analytics": "^0.1.8",
         "@vercel/nft": "^0.22.1",
+        "esbuild": "^0.17.12",
         "fast-glob": "^3.2.11",
         "set-cookie-parser": "^2.5.1",
         "web-vitals": "^3.1.1"
@@ -16511,135 +16531,135 @@
       "dev": true
     },
     "@esbuild/android-arm": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.13.tgz",
-      "integrity": "sha512-5tZZ/hLIfBmt7E8JsE5KbsknoAFmoElkg+A/gjyPtmSQvJjPf+9GsSJihid8VMa08lrsYyaEXOT9RLh3xXQONw==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
       "optional": true
     },
     "@esbuild/android-arm64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.13.tgz",
-      "integrity": "sha512-F5DgvJMV2ZEpLNpPCO7FEk1wy8O5tg6cikWSB6uvvncsgE1xgbPlm+Boio/4820C2/mj713X83X1h01v0qoeHg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
       "optional": true
     },
     "@esbuild/android-x64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.13.tgz",
-      "integrity": "sha512-5m1UUslzpfVrumG3m3Zv2x9VNAcvMOQWJy009y6jt10tcHpzIq2/b0I0k4fz0QYqGSNS1GteRIhVPN4H7OyCXg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
       "optional": true
     },
     "@esbuild/darwin-arm64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.13.tgz",
-      "integrity": "sha512-TXbXp/05r7heRsG8yWwbHw9diay+wXIyRNcIHFoNARRIGahYbTW/qwJzE37zkfxLIUPHgR/SyLTUlnTICg14ag==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
       "optional": true
     },
     "@esbuild/darwin-x64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.13.tgz",
-      "integrity": "sha512-Ku9Db2sblCxFvQdEO7X9nBaLR/S81uch81e2Q2+Os5z1NcnsFjuqhIYH0Gm6KNNpIKaEbC7gCLbiIPbLLMX4Pg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
       "optional": true
     },
     "@esbuild/freebsd-arm64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.13.tgz",
-      "integrity": "sha512-t1T5/nIf2j+FdSf1Fa3dcU0cXycr0nK4xJe52qjWa+1I249mM5NBY1ODjiabZxZ0x3CG05y4fd9bxfDLy9kQtA==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
       "optional": true
     },
     "@esbuild/freebsd-x64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.13.tgz",
-      "integrity": "sha512-/zbkgEO4gY2qGZr9UNAGI38w/FwUY4bx4EC88k9VeiCKNr3ukNgwH/oIgB5Z9/OqpkNLlcS4w9e2d/MIiy5fbw==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
       "optional": true
     },
     "@esbuild/linux-arm": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.13.tgz",
-      "integrity": "sha512-RrhjzrCF6aCDH248nUAQoldnRmN7nHMxv85GOj5AH+qkxxYvcig7fnUmgANngntRu4btXhN9WKHMgQ5seERDMw==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
       "optional": true
     },
     "@esbuild/linux-arm64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.13.tgz",
-      "integrity": "sha512-siu3QZrQ7eGrSttvFaRKyjT7kNRbUuHEKzCCyqRh19MbpGokGY13jbIsBEjx6JmH3T50hds325oweS9Ey2ihAQ==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
       "optional": true
     },
     "@esbuild/linux-ia32": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.13.tgz",
-      "integrity": "sha512-ADHA1PqP5gIegehVP0RvxMmNPxpLgetI8QCwYOjUheGXKIKWSdUN8ZS3rusQv3NGZmFCpYdMZzFoI0QtzzGAdw==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
       "optional": true
     },
     "@esbuild/linux-loong64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.13.tgz",
-      "integrity": "sha512-n1JQPxETmR0brkpWlJHeohReEPLH+m00bnJdNnFyHN3zLBt1QypevuZSmnmFWsC+7r7HTwWILj3lBDjtPH3ydg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
       "optional": true
     },
     "@esbuild/linux-mips64el": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.13.tgz",
-      "integrity": "sha512-d0pnD/j5KKQ43xtSIvOD+wNIy6D/Vh9GbXVRa3u4zCyiJMYWjxkPkbBzlEgNjdDmUM+5gBFen9k7B8Xscy+Myg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
       "optional": true
     },
     "@esbuild/linux-ppc64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.13.tgz",
-      "integrity": "sha512-C9sMpa/VcGLjVtsT01sXtzZNS7bAZ+icUclkKkiUwBQ9hzT+J+/Xpj+EykI5hB3KgtxQVo4XUahanFoZNxbQ1g==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
       "optional": true
     },
     "@esbuild/linux-riscv64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.13.tgz",
-      "integrity": "sha512-jYkc5EpNpvjccAHNYekiAtklusVGWftR0VVLtng7dJzDyy+5adAsf1fOG3LllP0WALxS55/w6boLE/728J/bXw==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
       "optional": true
     },
     "@esbuild/linux-s390x": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.13.tgz",
-      "integrity": "sha512-4jAJI5O6E/hATL4lsrG2A+noDjZ377KlATVFKwV3SWaNHj+OvoXe/T84ScQIXEtPI7ndJyLkMYruXj8RR5Ilyw==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
       "optional": true
     },
     "@esbuild/linux-x64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.13.tgz",
-      "integrity": "sha512-eFLQhJq98qijGRcv9je/9M4Mz1suZ+pOtj62ArsLd0gubNGhhQDz6T30X2X3f1KZ8lkKkr+zN5vtZzx1GAMoFw==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
       "optional": true
     },
     "@esbuild/netbsd-x64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.13.tgz",
-      "integrity": "sha512-F8PXDeT+3eQpPjf4bmNJapPLu0SKKlWRGPQvBQqVS+YDGoMKnyyYp2UENLFMV8zT7kS39zKxZRZvUL3fMz/7Ww==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
       "optional": true
     },
     "@esbuild/openbsd-x64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.13.tgz",
-      "integrity": "sha512-9jWfzbFCnIZdHjNs+00KQHArUbp7kjQDNmiuqkwGOQFs67m4/dKNupBv2DP5hTqVlQY4tW4RG3qpb6Y3zOHJeA==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
       "optional": true
     },
     "@esbuild/sunos-x64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.13.tgz",
-      "integrity": "sha512-ALbOMlTIBkAVi6KqYjONa7u2oH95RN7OpetFqMtjufFLBiSaayRuwUzhs2yuR9CfGT4qi0jv6HQDav+EG314TQ==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
       "optional": true
     },
     "@esbuild/win32-arm64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.13.tgz",
-      "integrity": "sha512-FJBLYL4PkrZGeuHzEqme+0DjNetxkJ+XbB+Aoeow7aQ53JCwsA0/mo8sS5aPkDHgCnMkN4A5GLoFTlDj3BKDrQ==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
       "optional": true
     },
     "@esbuild/win32-ia32": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.13.tgz",
-      "integrity": "sha512-Qrvst9RkLz4qgi3hqswNliYuKW92/HGJnd7xLWkGaGPa8S4qsONf81FW0ebDc5iUHb0I7QJwQATutvghTabnFA==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
       "optional": true
     },
     "@esbuild/win32-x64": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.13.tgz",
-      "integrity": "sha512-pZ/NIgz861XaUPlIkPFjP55nJ4PJa0o/CD4zgeRb1Q9FVE+8GvdB6ifJcK05jRhny5hKExhnRFIdgHmmCYH8vg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
       "optional": true
     },
     "@gar/promisify": {
@@ -18652,13 +18672,13 @@
       "integrity": "sha512-97a+l2LBU3Op3bBQEff79i/E4jMD2ZLFD8rHx9B6mXyB2uQwhJQYfiDqUwtfjF4QA1F2qs//N6Cw8LetMbQjcw=="
     },
     "astro": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-2.4.5.tgz",
-      "integrity": "sha512-osxLnuLXaOX0FjWOVQH8cmK4N/Gdj/ZdEkeyMJWsUss7xQU4Q64tAxB/dAv75f/XZiu+PprmndJkyQ4sYLOv1g==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-2.5.3.tgz",
+      "integrity": "sha512-ZRk599V3f2dAW2+WIEi1eAhHaxqxYsp2VAAhcUp103OEw8UZIeEa7KU1xZ+cKDqaBszSnTs38EdLjwHWWXCqMw==",
       "requires": {
         "@astrojs/compiler": "^1.4.0",
         "@astrojs/language-server": "^1.0.0",
-        "@astrojs/markdown-remark": "^2.2.0",
+        "@astrojs/markdown-remark": "^2.2.1",
         "@astrojs/telemetry": "^2.1.1",
         "@astrojs/webapi": "^2.1.1",
         "@babel/core": "^7.18.2",
@@ -18680,12 +18700,14 @@
         "devalue": "^4.2.0",
         "diff": "^5.1.0",
         "es-module-lexer": "^1.1.0",
+        "esbuild": "^0.17.18",
         "estree-walker": "3.0.0",
         "execa": "^6.1.0",
         "fast-glob": "^3.2.11",
         "github-slugger": "^2.0.0",
         "gray-matter": "^4.0.3",
         "html-escaper": "^3.0.3",
+        "js-yaml": "^4.1.0",
         "kleur": "^4.1.4",
         "magic-string": "^0.27.0",
         "mime": "^3.0.0",
@@ -18711,10 +18733,23 @@
         "zod": "^3.20.6"
       },
       "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
         "estree-walker": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.0.tgz",
           "integrity": "sha512-s6ceX0NFiU/vKPiKvFdR83U1Zffu7upwZsGwpoqfg5rbbq1l50WQ5hCeIvM6E6oD4shUHCYMsiFPns4Jk0YfMQ=="
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "requires": {
+            "argparse": "^2.0.1"
+          }
         }
       }
     },
@@ -19899,32 +19934,32 @@
       "integrity": "sha512-2BMfqBDeVCcOlLaL1ZAfp+D868SczNpKArrTM3dhpd7dK/OVlogzY15qpUngt+LMTq5UC/csb9vVQAgupucSbA=="
     },
     "esbuild": {
-      "version": "0.17.13",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.13.tgz",
-      "integrity": "sha512-4ixMwdErBcQHgTBeoxnowENCPKWFAGxgTyKHMK8gqn9sZaC7ZNWFKtim16g2rzQ2b/FYyy3lIUUJboFtjolhqg==",
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
       "requires": {
-        "@esbuild/android-arm": "0.17.13",
-        "@esbuild/android-arm64": "0.17.13",
-        "@esbuild/android-x64": "0.17.13",
-        "@esbuild/darwin-arm64": "0.17.13",
-        "@esbuild/darwin-x64": "0.17.13",
-        "@esbuild/freebsd-arm64": "0.17.13",
-        "@esbuild/freebsd-x64": "0.17.13",
-        "@esbuild/linux-arm": "0.17.13",
-        "@esbuild/linux-arm64": "0.17.13",
-        "@esbuild/linux-ia32": "0.17.13",
-        "@esbuild/linux-loong64": "0.17.13",
-        "@esbuild/linux-mips64el": "0.17.13",
-        "@esbuild/linux-ppc64": "0.17.13",
-        "@esbuild/linux-riscv64": "0.17.13",
-        "@esbuild/linux-s390x": "0.17.13",
-        "@esbuild/linux-x64": "0.17.13",
-        "@esbuild/netbsd-x64": "0.17.13",
-        "@esbuild/openbsd-x64": "0.17.13",
-        "@esbuild/sunos-x64": "0.17.13",
-        "@esbuild/win32-arm64": "0.17.13",
-        "@esbuild/win32-ia32": "0.17.13",
-        "@esbuild/win32-x64": "0.17.13"
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
       }
     },
     "esbuild-android-64": {
@@ -25283,9 +25318,9 @@
       "dev": true
     },
     "vercel": {
-      "version": "29.3.6",
-      "resolved": "https://registry.npmjs.org/vercel/-/vercel-29.3.6.tgz",
-      "integrity": "sha512-fwld21d9WoCTUJcbyTWvq0c9VchUCJ2qs0kaczcYo9Vs8+ORnxC8FFgbysR2f7B4iwL2hUxTMEWkQGV2782LjQ==",
+      "version": "29.4.0",
+      "resolved": "https://registry.npmjs.org/vercel/-/vercel-29.4.0.tgz",
+      "integrity": "sha512-sVfg87dhF3q6Nhrr5zv2oaOU1zQQd+MlsjhdNkB9MfrQyXqluAdHKiNz0+g/+wJeh/y7sUhWk2/XJb5CDlF70w==",
       "dev": true,
       "requires": {
         "@vercel/build-utils": "6.7.3",

--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
     "update:showcase": "node scripts/update-showcase.mjs"
   },
   "dependencies": {
-    "@astrojs/markdown-remark": "^2.1.4",
-    "@astrojs/mdx": "^0.19.1",
-    "@astrojs/rss": "^2.4.1",
-    "@astrojs/sitemap": "^1.2.2",
-    "@astrojs/tailwind": "^3.1.2",
-    "@astrojs/vercel": "^3.3.0",
+    "@astrojs/markdown-remark": "^2.2.1",
+    "@astrojs/mdx": "^0.19.3",
+    "@astrojs/rss": "^2.4.3",
+    "@astrojs/sitemap": "^1.3.1",
+    "@astrojs/tailwind": "^3.1.3",
+    "@astrojs/vercel": "^3.4.0",
     "@vercel/analytics": "^1.0.1",
-    "astro": "^2.4.5",
+    "astro": "^2.5.3",
     "daisyui": "^2.51.6",
     "tailwindcss": "^3.3.2",
     "theme-change": "^2.5.0"
@@ -33,6 +33,6 @@
     "parse-github-url": "^1.0.2",
     "reading-time": "^1.5.0",
     "rehype-autolink-headings": "^6.1.1",
-    "vercel": "^29.3.6"
+    "vercel": "^29.4.0"
   }
 }


### PR DESCRIPTION
Double-check the impact of:
- `@astrojs/markdown-remark`: 2.1.4 → 2.2.1
  - [2.2.0](https://github.com/withastro/astro/releases/tag/%40astrojs%2Fmarkdown-remark%402.2.0)
  - [2.2.1](https://github.com/withastro/astro/releases/tag/%40astrojs%2Fmarkdown-remark%402.2.1)
- `@astrojs/mdx`: 0.19.1 → 0.19.2
  - [0.19.2](https://github.com/withastro/astro/releases/tag/%40astrojs%2Fmdx%400.19.2)
  - [0.19.3](https://github.com/withastro/astro/blob/refs/heads/main/packages/integrations/mdx/CHANGELOG.md#0193)
- `@astrojs/rss`: 2.4.1 → 2.4.3
  - [2.4.2](https://github.com/withastro/astro/releases/tag/%40astrojs%2Frss%402.4.2)
  - [2.4.3](https://github.com/withastro/astro/releases/tag/%40astrojs%2Frss%402.4.3)
- `@astrojs/sitemap`: 1.2.2 → 1.3.1
  - [1.3.0](https://github.com/withastro/astro/releases/tag/%40astrojs%2Fsitemap%401.3.0): couldn't be bumped because broken the sitemap (fixed by 1.3.1)
  - [1.3.1](https://github.com/withastro/astro/releases/tag/%40astrojs%2Fsitemap%401.3.1): `rss.xml` appears in `sitemap-0.xml` but I suppose we can live with it. Already tracked upstream.
- `@astrojs/tailwind`: 3.1.2 → 3.1.3
  - [3.1.3](https://github.com/withastro/astro/releases/tag/%40astrojs%2Ftailwind%403.1.3) 
- `@astrojs/vercel`: 3.3.0 → 3.4.0
  - [3.4.0](https://github.com/withastro/astro/releases/tag/%40astrojs%2Fvercel%403.4.0)
- `astro`: 2.4.5 → 2.5.2
  - [2.5.3](https://github.com/withastro/astro/blob/refs/heads/main/packages/astro/CHANGELOG.md#253) 
  - [2.5.2](https://github.com/withastro/astro/releases/tag/astro%402.5.2)
  - [2.5.1](https://github.com/withastro/astro/releases/tag/astro%402.5.1)
  - [2.5.0](https://github.com/withastro/astro/releases/tag/astro%402.5.0)
    - enables experimental support for hybrid SSR with pre-rendering enabled by default. But let's wait for it not to be experimental anymore.
    - [ ] Create an issue to evaluate the impact of "Content collections now support data formats including JSON and YAML. You can also create relationships, or references, between collections to pull information from one collection entry into another." (done via https://github.com/withastro/astro/commit/c6d7ebefdd554a9ef29cfeb426ac55cab80d6473)
    - [ ] Create an issue to test `compressHTML` (done via https://github.com/withastro/astro/commit/763ff2d1e44f54b899d7c65386f1b4b877c95737)
- `vercel`: 29.3.6 → 29.4.0