### PR TITLE
fix: improve selection colors readability

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -121,3 +121,8 @@ main {
 	outline-offset: 2px;
 	box-shadow: hsl(var(--b1)) 0 0 0 2px;
 }
+
+::selection {
+	background: hsl(var(--p));
+	color: hsl(var(--pc));
+}


### PR DESCRIPTION
### Related issues

This PR closes #67.

### Description

As discussed earlier, this PR relies on DaisyUI CSS variables to use the primary color and its content variation for selections.

It should be noted that if some elements ever need different colors for their selection, a custom class could be used to override the default color, or just using a Tailwind class, e.g. `selection:bg-secondary`.

### Motivation & Context

This PR aims to improve the readability of the selection colors. More context can be found in #67.

### Type of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Open-reSource/openresource.dev/blob/main/CONTRIBUTING.md)
