### PR TITLE
feat: add skip link

### DIFF
--- a/src/components/SkipLink.astro
+++ b/src/components/SkipLink.astro
@@ -1,0 +1,6 @@
+<a
+  class="bg-secondary text-secondary-content sr-only focus:not-sr-only focus:absolute focus:top-1 focus:left-1 focus:p-4 focus:z-10 focus-visible:outline-offset-0"
+  href="#content"
+>
+  Skip to content
+</a>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import '../global.css';
 import ProgressScroll from '../components/ProgressScroll.astro';
+import SkipLink from '../components/SkipLink.astro';
 
 export interface Props {
 	description: string;
@@ -45,8 +46,9 @@ const { home = false, title, description, progressScroll = false } = Astro.props
 		<title>Open &lcub;re&rcub;Source - {title}</title>
 	</head>
 	<body>
+    <SkipLink />
 		<Header />
-		<main class={home ? `px-0 pb-0` : `mx-auto max-w-7xl px-2 sm:px-6 lg:px-8`}>
+		<main class={home ? `px-0 pb-0` : `mx-auto max-w-7xl px-2 sm:px-6 lg:px-8`} id="content">
 			<slot />
 		</main>
 		<Footer divider={ !home } />


### PR DESCRIPTION
### Related issues

This issue closes #16.

### Description

As a heavy keyboard user, I noticed that no link to skip to the main content is present on the page. I also saw that an issue was already opened for this and as I had some time, I decided to work on it. Hope that's okay!

This PR adds a link to skip to the main content. It is hidden by default and only appears when the user focuses it.

<img width="1300" alt="image" src="https://github.com/Open-reSource/openresource.dev/assets/494699/4004c41c-9f79-476f-9134-874dce70859c">

Design-wise, it's heavily inspired by the GitHub one but feel free to change it if you want to.

<img width="1284" alt="image" src="https://github.com/Open-reSource/openresource.dev/assets/494699/dfcf88a5-e04a-4b1d-81ef-af061f207c5a">

It uses Tailwind [screen readers utilities](https://tailwindcss.com/docs/screen-readers#screen-reader-only-elements) to hide the link by default and show it when focused.

### Motivation & Context

As stated in #16, the reasons are a obvious.

### Type of changes

- New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Open-reSource/openresource.dev/blob/main/CONTRIBUTING.md)