### PR TITLE
chore(deps): bump astro from 2.5.3 to 2.5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@astrojs/tailwind": "^3.1.3",
         "@astrojs/vercel": "^3.4.0",
         "@vercel/analytics": "^1.0.1",
-        "astro": "^2.5.3",
+        "astro": "^2.5.4",
         "daisyui": "^2.51.6",
         "tailwindcss": "^3.3.2",
         "theme-change": "^2.5.0"
@@ -5148,9 +5148,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-2.5.3.tgz",
-      "integrity": "sha512-ZRk599V3f2dAW2+WIEi1eAhHaxqxYsp2VAAhcUp103OEw8UZIeEa7KU1xZ+cKDqaBszSnTs38EdLjwHWWXCqMw==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-2.5.4.tgz",
+      "integrity": "sha512-mTeXK44fJU3xX0hvwyY+BXjunpzMRcSvVEu2GpduLU4XfoPy+pbvyBphbwYq360hXupfiJbqFpRc7gLlWKSoGg==",
       "dependencies": {
         "@astrojs/compiler": "^1.4.0",
         "@astrojs/language-server": "^1.0.0",
@@ -5188,6 +5188,7 @@
         "magic-string": "^0.27.0",
         "mime": "^3.0.0",
         "ora": "^6.1.0",
+        "p-limit": "^4.0.0",
         "path-to-regexp": "^6.2.1",
         "preferred-pm": "^3.0.3",
         "prompts": "^2.4.2",
@@ -5243,6 +5244,31 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/astro/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/astro/node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/async-listen": {
@@ -18672,9 +18698,9 @@
       "integrity": "sha512-97a+l2LBU3Op3bBQEff79i/E4jMD2ZLFD8rHx9B6mXyB2uQwhJQYfiDqUwtfjF4QA1F2qs//N6Cw8LetMbQjcw=="
     },
     "astro": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-2.5.3.tgz",
-      "integrity": "sha512-ZRk599V3f2dAW2+WIEi1eAhHaxqxYsp2VAAhcUp103OEw8UZIeEa7KU1xZ+cKDqaBszSnTs38EdLjwHWWXCqMw==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-2.5.4.tgz",
+      "integrity": "sha512-mTeXK44fJU3xX0hvwyY+BXjunpzMRcSvVEu2GpduLU4XfoPy+pbvyBphbwYq360hXupfiJbqFpRc7gLlWKSoGg==",
       "requires": {
         "@astrojs/compiler": "^1.4.0",
         "@astrojs/language-server": "^1.0.0",
@@ -18712,6 +18738,7 @@
         "magic-string": "^0.27.0",
         "mime": "^3.0.0",
         "ora": "^6.1.0",
+        "p-limit": "^4.0.0",
         "path-to-regexp": "^6.2.1",
         "preferred-pm": "^3.0.3",
         "prompts": "^2.4.2",
@@ -18750,6 +18777,19 @@
           "requires": {
             "argparse": "^2.0.1"
           }
+        },
+        "p-limit": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+          "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+          "requires": {
+            "yocto-queue": "^1.0.0"
+          }
+        },
+        "yocto-queue": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+          "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@astrojs/tailwind": "^3.1.3",
     "@astrojs/vercel": "^3.4.0",
     "@vercel/analytics": "^1.0.1",
-    "astro": "^2.5.3",
+    "astro": "^2.5.4",
     "daisyui": "^2.51.6",
     "tailwindcss": "^3.3.2",
     "theme-change": "^2.5.0"


### PR DESCRIPTION
### Description

This PR bumps `astro` dependency from `2.5.3` to `2.5.4`

Based on [astro 2.5.4](https://github.com/withastro/astro/releases/tag/astro%402.5.4), there's apparently no modification to do in this repo, nor impacts.