### PR TITLE
chore(deps): bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/markdown-remark": "^2.2.1",
-        "@astrojs/mdx": "^0.19.3",
+        "@astrojs/mdx": "^0.19.4",
         "@astrojs/rss": "^2.4.3",
         "@astrojs/sitemap": "^1.3.1",
         "@astrojs/tailwind": "^3.1.3",
         "@astrojs/vercel": "^3.4.0",
         "@vercel/analytics": "^1.0.1",
-        "astro": "^2.5.4",
+        "astro": "^2.5.5",
         "daisyui": "^2.51.6",
         "tailwindcss": "^3.3.2",
         "theme-change": "^2.5.0"
@@ -130,9 +130,9 @@
       "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw=="
     },
     "node_modules/@astrojs/mdx": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-0.19.3.tgz",
-      "integrity": "sha512-XiIQRO1OlJ19jqaZuttt6TSvnEIIiOVkHiNXPCOOsHnRpbLFuv0y0FoFuhYYRTHHm4rfSV2BRP5INiD5Aq9ByA==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-0.19.4.tgz",
+      "integrity": "sha512-+xT4YiUmOXwBqZ2zr74M7lznJ8wg6Q1Be534fJq24ozRxlkwEM6Qj/h9s3oSk6CwV7DuEf6KosRR0ltWE/OxJg==",
       "dependencies": {
         "@astrojs/markdown-remark": "^2.2.1",
         "@astrojs/prism": "^2.1.2",
@@ -5148,9 +5148,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-2.5.4.tgz",
-      "integrity": "sha512-mTeXK44fJU3xX0hvwyY+BXjunpzMRcSvVEu2GpduLU4XfoPy+pbvyBphbwYq360hXupfiJbqFpRc7gLlWKSoGg==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-2.5.5.tgz",
+      "integrity": "sha512-VRwnlfRtPALeOxfE4e7To5Vlu9pGwlTRWN1zkn1QTizwfg0rLirFTm6t2MCG/fUhlu/p3QO9tz8SpAIyDq53/Q==",
       "dependencies": {
         "@astrojs/compiler": "^1.4.0",
         "@astrojs/language-server": "^1.0.0",
@@ -15187,9 +15187,9 @@
       }
     },
     "@astrojs/mdx": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-0.19.3.tgz",
-      "integrity": "sha512-XiIQRO1OlJ19jqaZuttt6TSvnEIIiOVkHiNXPCOOsHnRpbLFuv0y0FoFuhYYRTHHm4rfSV2BRP5INiD5Aq9ByA==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-0.19.4.tgz",
+      "integrity": "sha512-+xT4YiUmOXwBqZ2zr74M7lznJ8wg6Q1Be534fJq24ozRxlkwEM6Qj/h9s3oSk6CwV7DuEf6KosRR0ltWE/OxJg==",
       "requires": {
         "@astrojs/markdown-remark": "^2.2.1",
         "@astrojs/prism": "^2.1.2",
@@ -18698,9 +18698,9 @@
       "integrity": "sha512-97a+l2LBU3Op3bBQEff79i/E4jMD2ZLFD8rHx9B6mXyB2uQwhJQYfiDqUwtfjF4QA1F2qs//N6Cw8LetMbQjcw=="
     },
     "astro": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-2.5.4.tgz",
-      "integrity": "sha512-mTeXK44fJU3xX0hvwyY+BXjunpzMRcSvVEu2GpduLU4XfoPy+pbvyBphbwYq360hXupfiJbqFpRc7gLlWKSoGg==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-2.5.5.tgz",
+      "integrity": "sha512-VRwnlfRtPALeOxfE4e7To5Vlu9pGwlTRWN1zkn1QTizwfg0rLirFTm6t2MCG/fUhlu/p3QO9tz8SpAIyDq53/Q==",
       "requires": {
         "@astrojs/compiler": "^1.4.0",
         "@astrojs/language-server": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^2.2.1",
-    "@astrojs/mdx": "^0.19.3",
+    "@astrojs/mdx": "^0.19.4",
     "@astrojs/rss": "^2.4.3",
     "@astrojs/sitemap": "^1.3.1",
     "@astrojs/tailwind": "^3.1.3",
     "@astrojs/vercel": "^3.4.0",
     "@vercel/analytics": "^1.0.1",
-    "astro": "^2.5.4",
+    "astro": "^2.5.5",
     "daisyui": "^2.51.6",
     "tailwindcss": "^3.3.2",
     "theme-change": "^2.5.0"


### PR DESCRIPTION
### Description

- `@astrojs/mdx`: 0.19.3 → 0.19.4: [0.19.4](https://github.com/withastro/astro/releases/tag/%40astrojs/mdx%400.19.4) has no impact
- `astro`: 2.5.4 → 2.5.5: [2.5.5](https://github.com/withastro/astro/releases/tag/astro%402.5.5) has no impact