### PR TITLE
Search UI tweaks

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -116,7 +116,7 @@ main {
 	opacity: 1;
 }
 
-:focus-visible {
+:focus-visible:not(:is(.DocSearch-Input, .DocSearch-Hit > a)) {
 	outline: 4px solid hsl(var(--bc)) !important;
 	outline-offset: 2px;
 	box-shadow: hsl(var(--b1)) 0 0 0 2px;
@@ -125,4 +125,92 @@ main {
 ::selection {
 	background: hsl(var(--p));
 	color: hsl(var(--pc));
+}
+
+/* https://github.com/algolia/docsearch/blob/066539c2c91c3559dcf3a738c8c998693a02465c/packages/docsearch-css/src/_variables.css */
+.DocSearch {
+	--docsearch-text-color: hsl(var(--bc));
+	--docsearch-highlight-color: hsl(var(--p));
+	--docsearch-container-background: hsl(var(--nf) / 0.5);
+	--docsearch-muted-color: hsl(var(--bc) / 0.7);
+
+	--docsearch-modal-background: hsl(var(--b2));
+	/* https://github.com/saadeghi/daisyui/blob/0bf3f4ead3a560e595be37f1ec9ad6767a55544a/src/components/styled/modal.css#LL10C15-L10C52 */
+	--docsearch-modal-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+
+  --docsearch-searchbox-focus-background: hsl(var(--b1));
+  --docsearch-searchbox-shadow: inset 0 0 0 2px hsl(var(--p));
+
+	--docsearch-hit-color: hsl(var(--bc));
+  --docsearch-hit-active-color: hsl(var(--pc));
+  --docsearch-hit-background: hsl(var(--b1));
+  --docsearch-hit-shadow: none;
+
+	--docsearch-key-gradient: transparent;
+  --docsearch-key-shadow: none;
+
+	--docsearch-footer-background: hsl(var(--b3));
+  --docsearch-footer-shadow: 0 -1px 0 0 hsl(var(--b1) / 0.4);
+}
+
+.DocSearch.DocSearch-Button {
+	border-radius: var(--rounded-btn);
+	margin: 0;
+}
+
+.DocSearch.DocSearch-Button:hover {
+	background-color: hsl(var(--nf));
+	color: hsl(var(--nc));
+	box-shadow: none;
+}
+
+.DocSearch.DocSearch-Button:hover :is(.DocSearch-Search-Icon, .DocSearch-Button-Key) {
+	color: hsl(var(--nc));
+}
+
+.DocSearch.DocSearch-Button:hover .DocSearch-Button-Keys {
+	border-color: hsl(var(--nc) / 0.4);
+}
+
+.DocSearch.DocSearch-Button:focus {
+	box-shadow: none;
+}
+
+.DocSearch .DocSearch-Button-Keys {
+	border: 1px solid hsl(var(--bc) / 0.3);
+	border-radius: calc(var(--rounded-btn) / 1.75);
+	min-width: auto;
+	padding: 0.15rem 0.25rem;
+}
+
+.DocSearch .DocSearch-Button-Key {
+	font-size: 0.75rem;
+	margin-right: 0;
+	padding: 0 0.1rem;
+	top: 0;
+	width: auto;
+}
+
+.DocSearch .DocSearch-Button-Key:first-child {
+	font-size: 1rem;
+}
+
+.DocSearch .DocSearch-Input {
+	outline: none;
+}
+
+.DocSearch .DocSearch-Hit-source {
+	color: hsl(var(--bc));
+}
+
+.DocSearch .DocSearch-Hits mark {
+	color: hsl(var(--s));
+}
+
+.DocSearch .DocSearch-Help a {
+	color: hsl(var(--p));
+}
+
+.DocSearch .DocSearch-Help a:hover {
+	text-decoration: underline;
 }

--- a/src/global.css
+++ b/src/global.css
@@ -154,6 +154,7 @@ main {
 }
 
 .DocSearch.DocSearch-Button {
+	background-color: transparent;
 	border-radius: var(--rounded-btn);
 	margin: 0;
 }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,6 +5,8 @@ import '../global.css';
 import ProgressScroll from '../components/ProgressScroll.astro';
 import SkipLink from '../components/SkipLink.astro';
 
+import '@docsearch/css';
+
 export interface Props {
 	description: string;
 	home?: boolean;
@@ -60,8 +62,6 @@ const { home = false, title, description, progressScroll = false } = Astro.props
 	import { inject } from '@vercel/analytics';
 
   import docsearch from '@docsearch/js';
-
-  import '@docsearch/css';
 
   docsearch({
     appId: 'H12KLKNKCO',

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -69,6 +69,16 @@ const { home = false, title, description, progressScroll = false } = Astro.props
     indexName: 'openresource',
     apiKey: '11f67572e786353afae4fb75d30b26a8',
     placeholder: 'Search Open {re}Source',
+    getMissingResultsUrl: ({ query }) => {
+      let queryExcerpt = encodeURIComponent(query);
+      const description = encodeURIComponent(`The search query "${query}" did not return any results.`);
+
+      if (queryExcerpt.length > 30) {
+        queryExcerpt = `${queryExcerpt.substring(0, 30)}…`;
+      }
+
+      return `https://github.com/Open-reSource/openresource.dev/issues/new?template=bug_report.yml&title=Search%20missing%20results%20for%20%22${queryExcerpt}%22&what-happened=${description}`;
+    },
   });
 
  	inject();

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -68,6 +68,7 @@ const { home = false, title, description, progressScroll = false } = Astro.props
     container: '#docsearch',
     indexName: 'openresource',
     apiKey: '11f67572e786353afae4fb75d30b26a8',
+    placeholder: 'Search Open {re}Source',
   });
 
  	inject();


### PR DESCRIPTION
### Related issues

This pull request is a follow-up of #85.

### Description

This pull request tweaks various aspects of the newly introduced search feature.

First, the search input placeholder has been updated from `"Search docs"` to `"Search Open {re}Source"`.

When the search does not return any results, the user is now presented with a message that reads `"Believe this query should return results? Let us know."` with a link to create a new issue with the title and body already pre-filled with the query. Note that it's not possible to pre-fill the OS and browser as this is [not yet supported](https://github.com/orgs/community/discussions/44983) by GitHub.

<img width="894" alt="image" src="https://github.com/Open-reSource/openresource.dev/assets/494699/126be8c4-f0d1-4b0f-8ee5-1034efb05682">

Then, the search UI has been tweaked and uses DaisyUI CSS Variables as much as possible. This gives a more personalized look to the search UI adapting to the current theme. I think this is only a first step and may require some more tweaks in the future, specially color-wise as some theme colors combinations are not that great, or maybe at some point even reduce the number of themes available.

![hover](https://github.com/Open-reSource/openresource.dev/assets/494699/4e228964-2f87-4dee-879b-850f486c578c)

<img width="1108" alt="image" src="https://github.com/Open-reSource/openresource.dev/assets/494699/8ec04fd8-1edb-4a0f-b037-31dde4ebd51f">

<img width="1108" alt="image" src="https://github.com/Open-reSource/openresource.dev/assets/494699/c93df5b0-40cf-4ba6-b944-f3ac7cb2cc6e">

<img width="1108" alt="image" src="https://github.com/Open-reSource/openresource.dev/assets/494699/da38b22f-e888-4ced-9e8c-7d14a1b79b7b">

<img width="1108" alt="image" src="https://github.com/Open-reSource/openresource.dev/assets/494699/81eff232-b55e-4f30-922c-99aeed48abf5">

### Motivation & Context

These changes provide a search experience adapted to the current theme.

### Type of changes

- New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Open-reSource/openresource.dev/blob/main/CONTRIBUTING.md)