### PR TITLE
feat(search): change issue creation URL when search without results

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -77,7 +77,7 @@ const { home = false, title, description, progressScroll = false } = Astro.props
         queryExcerpt = `${queryExcerpt.substring(0, 30)}…`;
       }
 
-      return `https://github.com/Open-reSource/openresource.dev/issues/new?template=bug_report.yml&title=Search%20missing%20results%20for%20%22${queryExcerpt}%22&what-happened=${description}`;
+      return `https://github.com/Open-reSource/openresource.dev/issues/new?title=Search%20missing%20results%20for%20%22${queryExcerpt}%22&body=${description}&labels=enhancement,search`
     },
   });
 


### PR DESCRIPTION
### Related issues

This pull request is a follow-up of https://github.com/Open-reSource/openresource.dev/pull/91.

### Description

When the search doesn't return any results, users can click on a link where "Believe this query should return results? Let us know." message is presented to them.

Originally, the link was to our bug template but needed the user to select the operating system(s) which was an extra step not useful to report search errors/enhancement.

This PR changes this link to an empty issue creation with a pre-filled title and a description, plus an "enhancement" label, and a newly created "search" label.

Example of link: https://github.com/Open-reSource/openresource.dev/issues/new?title=Search%20missing%20results%20for%20%22dfsfds%22&body=The%20search%20query%20%22dfsfds%22%20did%20not%20return%20any%20results.&labels=enhancement,search

![Screenshot 2023-05-26 at 13 32 51](https://github.com/Open-reSource/openresource.dev/assets/17381666/c5d5efb2-323e-481e-9a02-ad65bdf3c58e)


### Type of changes

- New-feature (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Open-reSource/openresource.dev/blob/main/CONTRIBUTING.md)
