### PR TITLE
chore(deps): bump astro from 2.6.6 to 2.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@astrojs/tailwind": "^4.0.0",
         "@astrojs/vercel": "^3.5.0",
         "@vercel/analytics": "^1.0.1",
-        "astro": "^2.6.6",
+        "astro": "^2.7.0",
         "daisyui": "^2.52.0",
         "gemoji": "^8.1.0",
         "tailwindcss": "^3.3.2",
@@ -255,9 +255,9 @@
       }
     },
     "node_modules/@astrojs/compiler": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-1.4.1.tgz",
-      "integrity": "sha512-aXAxapNWZwGN41P+Am/ma/2kAzKOhMNaY6YuvLkUHFv+UZkmDHD6F0fE1sQA2Up0bLjgPQa1VQzoAaii5tZWaA=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-1.5.1.tgz",
+      "integrity": "sha512-iIGKu/uzB8sJ5VveQf0eHrVPPFEcrvSlp4qShYMOuY2aMmK2RVXQlX9dUjtmBQ+NAokfIOb7fwCutvH+p13l+g=="
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.1.0",
@@ -463,20 +463,20 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.21.8",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.8.tgz",
-      "integrity": "sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.5.tgz",
+      "integrity": "sha512-SBuTAjg91A3eKOvD+bPEz3LlhHZRNu1nFOVts9lzDJTXshHTjII0BAtDS3Y2DAkdZdDKWVZGVwkDfc4Clxn1dg==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.21.4",
-        "@babel/generator": "^7.21.5",
-        "@babel/helper-compilation-targets": "^7.21.5",
-        "@babel/helper-module-transforms": "^7.21.5",
-        "@babel/helpers": "^7.21.5",
-        "@babel/parser": "^7.21.8",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.5",
-        "@babel/types": "^7.21.5",
+        "@babel/code-frame": "^7.22.5",
+        "@babel/generator": "^7.22.5",
+        "@babel/helper-compilation-targets": "^7.22.5",
+        "@babel/helper-module-transforms": "^7.22.5",
+        "@babel/helpers": "^7.22.5",
+        "@babel/parser": "^7.22.5",
+        "@babel/template": "^7.22.5",
+        "@babel/traverse": "^7.22.5",
+        "@babel/types": "^7.22.5",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -860,13 +860,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.5.tgz",
-      "integrity": "sha512-BSY+JSlHxOmGsPTydUkPf1MdMQ3M81x5xGCOVgWM3G8XH77sJ292Y2oqcp0CbbgxhqBuI46iUz1tT7hqP7EfgA==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.5.tgz",
+      "integrity": "sha512-pSXRmfE1vzcUIDFQcSGA5Mr+GxBV9oiRKDuDxXvWQQBCh8HoIjs/2DlDB7H8smac1IVrB9/xdXj2N3Wol9Cr+Q==",
       "dependencies": {
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.5",
-        "@babel/types": "^7.21.5"
+        "@babel/template": "^7.22.5",
+        "@babel/traverse": "^7.22.5",
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1823,15 +1823,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.21.0.tgz",
-      "integrity": "sha512-6OAWljMvQrZjR2DaNhVfRz6dkCAVV+ymcLUmaf8bccGOHn2v5rHJK3tTpij0BuhdYWP4LLaqj5lwcdlpAAPuvg==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.5.tgz",
+      "integrity": "sha512-rog5gZaVbUip5iWDMTYbVM15XQq+RkUKhET/IHR6oizR+JEoN6CAfTTuHcK4vwUyzca30qqHqEpzBOnaRMWYMA==",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-jsx": "^7.18.6",
-        "@babel/types": "^7.21.0"
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-module-imports": "^7.22.5",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-jsx": "^7.22.5",
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -4032,9 +4032,9 @@
       }
     },
     "node_modules/@types/babel__core": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
-      "integrity": "sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
+      "integrity": "sha512-aACu/U/omhdk15O4Nfb+fHgH/z3QsfQzpnvRZhYhThms83ZnAOZz7zZAWO7mn2yyNQaA4xTO8GLK3uqFU4bYYw==",
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -4061,11 +4061,11 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.3.tgz",
-      "integrity": "sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.1.tgz",
+      "integrity": "sha512-MitHFXnhtgwsGZWtT68URpOvLN4EREih1u3QtQiN4VdAxWKRVvGCSvw/Qth0M0Qq3pJpnGOu5JaM/ydK7OGbqg==",
       "dependencies": {
-        "@babel/types": "^7.3.0"
+        "@babel/types": "^7.20.7"
       }
     },
     "node_modules/@types/cacheable-request": {
@@ -5332,9 +5332,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
+      "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5628,39 +5628,39 @@
       }
     },
     "node_modules/astro": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-2.6.6.tgz",
-      "integrity": "sha512-npeTXVaSOWKYYF6Znj6Yfxfq+WIFZ9u/Q+vtFP3nXbl7/XimvE+LbmWoK+hPFBOXC/KRLHxqQSltXJX5ALFmFg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-2.7.0.tgz",
+      "integrity": "sha512-gUYx2R0V7fpZtFRN9f4nE0We95qYhJyAr+VW0nVFqlMMF1of9MzrjjJ+8rIGJ/6RooFK8XAaXWTQMGTok3ZzEA==",
       "dependencies": {
-        "@astrojs/compiler": "^1.4.0",
+        "@astrojs/compiler": "^1.5.0",
         "@astrojs/internal-helpers": "^0.1.0",
         "@astrojs/language-server": "^1.0.0",
         "@astrojs/markdown-remark": "^2.2.1",
         "@astrojs/telemetry": "^2.1.1",
         "@astrojs/webapi": "^2.2.0",
-        "@babel/core": "^7.21.8",
-        "@babel/generator": "^7.18.2",
-        "@babel/parser": "^7.18.4",
-        "@babel/plugin-transform-react-jsx": "^7.17.12",
-        "@babel/traverse": "^7.18.2",
-        "@babel/types": "^7.21.5",
-        "@types/babel__core": "^7.1.19",
+        "@babel/core": "^7.22.5",
+        "@babel/generator": "^7.22.5",
+        "@babel/parser": "^7.22.5",
+        "@babel/plugin-transform-react-jsx": "^7.22.5",
+        "@babel/traverse": "^7.22.5",
+        "@babel/types": "^7.22.5",
+        "@types/babel__core": "^7.20.1",
         "@types/yargs-parser": "^21.0.0",
-        "acorn": "^8.8.2",
+        "acorn": "^8.9.0",
         "boxen": "^6.2.1",
         "chokidar": "^3.5.3",
-        "ci-info": "^3.3.1",
+        "ci-info": "^3.8.0",
         "common-ancestor-path": "^1.0.1",
         "cookie": "^0.5.0",
         "debug": "^4.3.4",
-        "deepmerge-ts": "^4.2.2",
+        "deepmerge-ts": "^4.3.0",
         "devalue": "^4.3.2",
         "diff": "^5.1.0",
-        "es-module-lexer": "^1.1.0",
-        "esbuild": "^0.17.18",
+        "es-module-lexer": "^1.3.0",
+        "esbuild": "^0.17.19",
         "estree-walker": "3.0.0",
         "execa": "^6.1.0",
-        "fast-glob": "^3.2.11",
+        "fast-glob": "^3.2.12",
         "github-slugger": "^2.0.0",
         "gray-matter": "^4.0.3",
         "html-escaper": "^3.0.3",
@@ -5668,26 +5668,26 @@
         "kleur": "^4.1.4",
         "magic-string": "^0.27.0",
         "mime": "^3.0.0",
-        "ora": "^6.1.0",
+        "ora": "^6.3.1",
         "p-limit": "^4.0.0",
         "path-to-regexp": "^6.2.1",
         "preferred-pm": "^3.0.3",
         "prompts": "^2.4.2",
         "rehype": "^12.0.1",
-        "semver": "^7.3.8",
+        "semver": "^7.5.2",
         "server-destroy": "^1.0.1",
         "shiki": "^0.14.1",
         "slash": "^4.0.0",
         "string-width": "^5.1.2",
-        "strip-ansi": "^7.0.1",
+        "strip-ansi": "^7.1.0",
         "supports-esm": "^1.0.0",
         "tsconfig-resolver": "^3.0.1",
         "typescript": "*",
-        "unist-util-visit": "^4.1.0",
-        "vfile": "^5.3.2",
-        "vite": "^4.3.1",
+        "unist-util-visit": "^4.1.2",
+        "vfile": "^5.3.7",
+        "vite": "^4.3.9",
         "vitefu": "^0.2.4",
-        "yargs-parser": "^21.0.1",
+        "yargs-parser": "^21.1.1",
         "zod": "^3.20.6"
       },
       "bin": {
@@ -5727,6 +5727,17 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/astro/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/astro/node_modules/p-limit": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
@@ -5740,6 +5751,25 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/astro/node_modules/semver": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/astro/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/astro/node_modules/yocto-queue": {
       "version": "1.0.0",
@@ -7455,9 +7485,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.2.0.tgz",
-      "integrity": "sha512-2BMfqBDeVCcOlLaL1ZAfp+D868SczNpKArrTM3dhpd7dK/OVlogzY15qpUngt+LMTq5UC/csb9vVQAgupucSbA=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
+      "integrity": "sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA=="
     },
     "node_modules/esbuild": {
       "version": "0.17.19",
@@ -11959,9 +11989,9 @@
       }
     },
     "node_modules/ora": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-6.3.0.tgz",
-      "integrity": "sha512-1/D8uRFY0ay2kgBpmAwmSA404w4OoPVhHMqRqtjvrcK/dnzcEZxMJ+V4DUbyICu8IIVRclHcOf5wlD1tMY4GUQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-6.3.1.tgz",
+      "integrity": "sha512-ERAyNnZOfqM+Ao3RAvIXkYh5joP220yf59gVe2X/cI6SiCxIdi4c9HZKZD8R6q/RDXEje1THBju6iExiSsgJaQ==",
       "dependencies": {
         "chalk": "^5.0.0",
         "cli-cursor": "^4.0.0",
@@ -14198,9 +14228,9 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -16250,9 +16280,9 @@
       }
     },
     "@astrojs/compiler": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-1.4.1.tgz",
-      "integrity": "sha512-aXAxapNWZwGN41P+Am/ma/2kAzKOhMNaY6YuvLkUHFv+UZkmDHD6F0fE1sQA2Up0bLjgPQa1VQzoAaii5tZWaA=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-1.5.1.tgz",
+      "integrity": "sha512-iIGKu/uzB8sJ5VveQf0eHrVPPFEcrvSlp4qShYMOuY2aMmK2RVXQlX9dUjtmBQ+NAokfIOb7fwCutvH+p13l+g=="
     },
     "@astrojs/internal-helpers": {
       "version": "0.1.0",
@@ -16434,20 +16464,20 @@
       "integrity": "sha512-4Jc/YuIaYqKnDDz892kPIledykKg12Aw1PYX5i/TY28anJtacvM1Rrr8wbieB9GfEJwlzqT0hUEao0CxEebiDA=="
     },
     "@babel/core": {
-      "version": "7.21.8",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.8.tgz",
-      "integrity": "sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.5.tgz",
+      "integrity": "sha512-SBuTAjg91A3eKOvD+bPEz3LlhHZRNu1nFOVts9lzDJTXshHTjII0BAtDS3Y2DAkdZdDKWVZGVwkDfc4Clxn1dg==",
       "requires": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.21.4",
-        "@babel/generator": "^7.21.5",
-        "@babel/helper-compilation-targets": "^7.21.5",
-        "@babel/helper-module-transforms": "^7.21.5",
-        "@babel/helpers": "^7.21.5",
-        "@babel/parser": "^7.21.8",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.5",
-        "@babel/types": "^7.21.5",
+        "@babel/code-frame": "^7.22.5",
+        "@babel/generator": "^7.22.5",
+        "@babel/helper-compilation-targets": "^7.22.5",
+        "@babel/helper-module-transforms": "^7.22.5",
+        "@babel/helpers": "^7.22.5",
+        "@babel/parser": "^7.22.5",
+        "@babel/template": "^7.22.5",
+        "@babel/traverse": "^7.22.5",
+        "@babel/types": "^7.22.5",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -16734,13 +16764,13 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.5.tgz",
-      "integrity": "sha512-BSY+JSlHxOmGsPTydUkPf1MdMQ3M81x5xGCOVgWM3G8XH77sJ292Y2oqcp0CbbgxhqBuI46iUz1tT7hqP7EfgA==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.5.tgz",
+      "integrity": "sha512-pSXRmfE1vzcUIDFQcSGA5Mr+GxBV9oiRKDuDxXvWQQBCh8HoIjs/2DlDB7H8smac1IVrB9/xdXj2N3Wol9Cr+Q==",
       "requires": {
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.5",
-        "@babel/types": "^7.21.5"
+        "@babel/template": "^7.22.5",
+        "@babel/traverse": "^7.22.5",
+        "@babel/types": "^7.22.5"
       }
     },
     "@babel/highlight": {
@@ -17356,15 +17386,15 @@
       }
     },
     "@babel/plugin-transform-react-jsx": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.21.0.tgz",
-      "integrity": "sha512-6OAWljMvQrZjR2DaNhVfRz6dkCAVV+ymcLUmaf8bccGOHn2v5rHJK3tTpij0BuhdYWP4LLaqj5lwcdlpAAPuvg==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.5.tgz",
+      "integrity": "sha512-rog5gZaVbUip5iWDMTYbVM15XQq+RkUKhET/IHR6oizR+JEoN6CAfTTuHcK4vwUyzca30qqHqEpzBOnaRMWYMA==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-jsx": "^7.18.6",
-        "@babel/types": "^7.21.0"
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-module-imports": "^7.22.5",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-jsx": "^7.22.5",
+        "@babel/types": "^7.22.5"
       }
     },
     "@babel/plugin-transform-regenerator": {
@@ -18807,9 +18837,9 @@
       }
     },
     "@types/babel__core": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
-      "integrity": "sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
+      "integrity": "sha512-aACu/U/omhdk15O4Nfb+fHgH/z3QsfQzpnvRZhYhThms83ZnAOZz7zZAWO7mn2yyNQaA4xTO8GLK3uqFU4bYYw==",
       "requires": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -18836,11 +18866,11 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.3.tgz",
-      "integrity": "sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.1.tgz",
+      "integrity": "sha512-MitHFXnhtgwsGZWtT68URpOvLN4EREih1u3QtQiN4VdAxWKRVvGCSvw/Qth0M0Qq3pJpnGOu5JaM/ydK7OGbqg==",
       "requires": {
-        "@babel/types": "^7.3.0"
+        "@babel/types": "^7.20.7"
       }
     },
     "@types/cacheable-request": {
@@ -19820,9 +19850,9 @@
       }
     },
     "acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw=="
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
+      "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ=="
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -20047,39 +20077,39 @@
       "integrity": "sha512-97a+l2LBU3Op3bBQEff79i/E4jMD2ZLFD8rHx9B6mXyB2uQwhJQYfiDqUwtfjF4QA1F2qs//N6Cw8LetMbQjcw=="
     },
     "astro": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-2.6.6.tgz",
-      "integrity": "sha512-npeTXVaSOWKYYF6Znj6Yfxfq+WIFZ9u/Q+vtFP3nXbl7/XimvE+LbmWoK+hPFBOXC/KRLHxqQSltXJX5ALFmFg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-2.7.0.tgz",
+      "integrity": "sha512-gUYx2R0V7fpZtFRN9f4nE0We95qYhJyAr+VW0nVFqlMMF1of9MzrjjJ+8rIGJ/6RooFK8XAaXWTQMGTok3ZzEA==",
       "requires": {
-        "@astrojs/compiler": "^1.4.0",
+        "@astrojs/compiler": "^1.5.0",
         "@astrojs/internal-helpers": "^0.1.0",
         "@astrojs/language-server": "^1.0.0",
         "@astrojs/markdown-remark": "^2.2.1",
         "@astrojs/telemetry": "^2.1.1",
         "@astrojs/webapi": "^2.2.0",
-        "@babel/core": "^7.21.8",
-        "@babel/generator": "^7.18.2",
-        "@babel/parser": "^7.18.4",
-        "@babel/plugin-transform-react-jsx": "^7.17.12",
-        "@babel/traverse": "^7.18.2",
-        "@babel/types": "^7.21.5",
-        "@types/babel__core": "^7.1.19",
+        "@babel/core": "^7.22.5",
+        "@babel/generator": "^7.22.5",
+        "@babel/parser": "^7.22.5",
+        "@babel/plugin-transform-react-jsx": "^7.22.5",
+        "@babel/traverse": "^7.22.5",
+        "@babel/types": "^7.22.5",
+        "@types/babel__core": "^7.20.1",
         "@types/yargs-parser": "^21.0.0",
-        "acorn": "^8.8.2",
+        "acorn": "^8.9.0",
         "boxen": "^6.2.1",
         "chokidar": "^3.5.3",
-        "ci-info": "^3.3.1",
+        "ci-info": "^3.8.0",
         "common-ancestor-path": "^1.0.1",
         "cookie": "^0.5.0",
         "debug": "^4.3.4",
-        "deepmerge-ts": "^4.2.2",
+        "deepmerge-ts": "^4.3.0",
         "devalue": "^4.3.2",
         "diff": "^5.1.0",
-        "es-module-lexer": "^1.1.0",
-        "esbuild": "^0.17.18",
+        "es-module-lexer": "^1.3.0",
+        "esbuild": "^0.17.19",
         "estree-walker": "3.0.0",
         "execa": "^6.1.0",
-        "fast-glob": "^3.2.11",
+        "fast-glob": "^3.2.12",
         "github-slugger": "^2.0.0",
         "gray-matter": "^4.0.3",
         "html-escaper": "^3.0.3",
@@ -20087,26 +20117,26 @@
         "kleur": "^4.1.4",
         "magic-string": "^0.27.0",
         "mime": "^3.0.0",
-        "ora": "^6.1.0",
+        "ora": "^6.3.1",
         "p-limit": "^4.0.0",
         "path-to-regexp": "^6.2.1",
         "preferred-pm": "^3.0.3",
         "prompts": "^2.4.2",
         "rehype": "^12.0.1",
-        "semver": "^7.3.8",
+        "semver": "^7.5.2",
         "server-destroy": "^1.0.1",
         "shiki": "^0.14.1",
         "slash": "^4.0.0",
         "string-width": "^5.1.2",
-        "strip-ansi": "^7.0.1",
+        "strip-ansi": "^7.1.0",
         "supports-esm": "^1.0.0",
         "tsconfig-resolver": "^3.0.1",
         "typescript": "*",
-        "unist-util-visit": "^4.1.0",
-        "vfile": "^5.3.2",
-        "vite": "^4.3.1",
+        "unist-util-visit": "^4.1.2",
+        "vfile": "^5.3.7",
+        "vite": "^4.3.9",
         "vitefu": "^0.2.4",
-        "yargs-parser": "^21.0.1",
+        "yargs-parser": "^21.1.1",
         "zod": "^3.20.6"
       },
       "dependencies": {
@@ -20128,6 +20158,14 @@
             "argparse": "^2.0.1"
           }
         },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "p-limit": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
@@ -20135,6 +20173,19 @@
           "requires": {
             "yocto-queue": "^1.0.0"
           }
+        },
+        "semver": {
+          "version": "7.5.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "yocto-queue": {
           "version": "1.0.0",
@@ -21373,9 +21424,9 @@
       "dev": true
     },
     "es-module-lexer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.2.0.tgz",
-      "integrity": "sha512-2BMfqBDeVCcOlLaL1ZAfp+D868SczNpKArrTM3dhpd7dK/OVlogzY15qpUngt+LMTq5UC/csb9vVQAgupucSbA=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
+      "integrity": "sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA=="
     },
     "esbuild": {
       "version": "0.17.19",
@@ -24497,9 +24548,9 @@
       }
     },
     "ora": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-6.3.0.tgz",
-      "integrity": "sha512-1/D8uRFY0ay2kgBpmAwmSA404w4OoPVhHMqRqtjvrcK/dnzcEZxMJ+V4DUbyICu8IIVRclHcOf5wlD1tMY4GUQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-6.3.1.tgz",
+      "integrity": "sha512-ERAyNnZOfqM+Ao3RAvIXkYh5joP220yf59gVe2X/cI6SiCxIdi4c9HZKZD8R6q/RDXEje1THBju6iExiSsgJaQ==",
       "requires": {
         "chalk": "^5.0.0",
         "cli-cursor": "^4.0.0",
@@ -26135,9 +26186,9 @@
       }
     },
     "strip-ansi": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "requires": {
         "ansi-regex": "^6.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@astrojs/tailwind": "^4.0.0",
     "@astrojs/vercel": "^3.5.0",
     "@vercel/analytics": "^1.0.1",
-    "astro": "^2.6.6",
+    "astro": "^2.7.0",
     "daisyui": "^2.52.0",
     "gemoji": "^8.1.0",
     "tailwindcss": "^3.3.2",


### PR DESCRIPTION
[astro@2.7.0](https://github.com/withastro/astro/releases/tag/astro%402.7.0):

> Remove legacy handling for MDX content collections. Ensure you are using `@astrojs/mdx` v0.18 or above:

No impact.

> `Astro.locals` is now exposed to the adapter API. Node Adapter can now pass in a `locals` object in the SSR handler middleware. 

Not used for now.

> Shipped a new SSR build configuration mode: `split`.

Created https://github.com/Open-reSource/openresource.dev/issues/127 to study it.
