### PR TITLE
chore(deps): bump dependencies

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -43,7 +43,12 @@ export default defineConfig({
   ],
   output: "server",
   adapter: vercel({
-    analytics: true
+    webAnalytics: {
+      enabled: true
+    },
+    speedInsights: {
+      enabled: true
+    }
   }),
   site: 'https://openresource.dev',
   // used for sitemap

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,14 +7,14 @@
     "": {
       "version": "0.0.1",
       "dependencies": {
-        "@astrojs/markdown-remark": "^3.1.0",
-        "@astrojs/mdx": "^1.0.0",
+        "@astrojs/markdown-remark": "^3.2.0",
+        "@astrojs/mdx": "^1.1.0",
         "@astrojs/rss": "^3.0.0",
         "@astrojs/sitemap": "^3.0.0",
         "@astrojs/tailwind": "^5.0.0",
-        "@astrojs/vercel": "^4.0.5",
+        "@astrojs/vercel": "^5.0.0",
         "@vercel/analytics": "^1.0.2",
-        "astro": "^3.0.8",
+        "astro": "^3.1.0",
         "daisyui": "^3.7.5",
         "gemoji": "^8.1.0",
         "tailwindcss": "^3.3.3",
@@ -25,7 +25,7 @@
         "@docsearch/js": "^3.5.2",
         "@faker-js/faker": "8.0.2",
         "@octokit/graphql": "^7.0.1",
-        "@octokit/graphql-schema": "^14.27.2",
+        "@octokit/graphql-schema": "^14.31.0",
         "@tailwindcss/typography": "^0.5.9",
         "@types/parse-github-url": "^1.0.0",
         "dotenv": "^16.3.1",
@@ -34,7 +34,7 @@
         "reading-time": "^1.5.0",
         "rehype-autolink-headings": "^7.0.0",
         "tsx": "^3.12.8",
-        "vercel": "^32.2.0",
+        "vercel": "^32.2.4",
         "vitest": "^0.34.3"
       }
     },
@@ -265,13 +265,14 @@
       "integrity": "sha512-NQ4ppp1CM0HNkKbJNM4saVSfmUYzGlRalF6wx7F6T/MYHYSWGuojY89/oFTy4t8VlOGUCUijlsVNNeziWaUo5g=="
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-3.1.0.tgz",
-      "integrity": "sha512-5UwamK0iFxN0n1Nw44vUk8AkQr4psKS63hM3D1/4bhhjs4ZFRyrYmg5NjScaMEXZcrd2KgGPsd+PEwNs4mlBOw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-3.2.0.tgz",
+      "integrity": "sha512-jigyLfefUZPKgVmmraCkVpdUuFH1R3SrpgQO13axsgwLDBgkggaQpNR5Ag4O9PDualeBtbdt30aYSfvnBKx9Hg==",
       "dependencies": {
         "@astrojs/prism": "^3.0.0",
         "github-slugger": "^2.0.0",
         "import-meta-resolve": "^3.0.0",
+        "mdast-util-definitions": "^6.0.0",
         "rehype-raw": "^6.1.1",
         "rehype-stringify": "^9.0.4",
         "remark-gfm": "^3.0.1",
@@ -284,16 +285,81 @@
         "vfile": "^5.3.7"
       },
       "peerDependencies": {
-        "astro": "^3.0.11"
+        "astro": "^3.1.0"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark/node_modules/@types/mdast": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.0.tgz",
+      "integrity": "sha512-YLeG8CujC9adtj/kuDzq1N4tCDYKoZ5l/bnjq8d74+t/3q/tHquJOJKUQXJrLCflOHpKjXgcI/a929gpmLOEng==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark/node_modules/@types/unist": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
+      "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
+    },
+    "node_modules/@astrojs/markdown-remark/node_modules/mdast-util-definitions": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+      "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark/node_modules/mdast-util-definitions/node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark/node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/@astrojs/mdx": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-1.0.0.tgz",
-      "integrity": "sha512-Gmeleci8o4X7dST9E85c1+k273zcKW8cSFgZLTwU5K4dC0qHfY/EaDKHWrtzOB2wjZlT1JDRzTJ68LJYGrF2OA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-1.1.0.tgz",
+      "integrity": "sha512-rmLZBw3CUCkp+5blBJloV2EqJGRaJTraJygWMfCvrLcCA3vzhwzACnVQKdUDlts8EEr6V6+HXYVqi46AVEfobg==",
       "dependencies": {
-        "@astrojs/markdown-remark": "3.0.0",
-        "@astrojs/prism": "3.0.0",
+        "@astrojs/markdown-remark": "3.2.0",
         "@mdx-js/mdx": "^2.3.0",
         "acorn": "^8.10.0",
         "es-module-lexer": "^1.3.0",
@@ -303,10 +369,8 @@
         "hast-util-to-html": "^8.0.4",
         "kleur": "^4.1.4",
         "rehype-raw": "^6.1.1",
-        "remark-frontmatter": "^4.0.1",
         "remark-gfm": "^3.0.1",
         "remark-smartypants": "^2.0.0",
-        "shiki": "^0.14.3",
         "source-map": "^0.7.4",
         "unist-util-visit": "^4.1.2",
         "vfile": "^5.3.7"
@@ -315,30 +379,7 @@
         "node": ">=18.14.1"
       },
       "peerDependencies": {
-        "astro": "^3.0.0"
-      }
-    },
-    "node_modules/@astrojs/mdx/node_modules/@astrojs/markdown-remark": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-3.0.0.tgz",
-      "integrity": "sha512-s8I49Je4++ImgYAgwL32HgN8m6we2qz3RtBpN4AjObMODPwDylmzUHZksD8Toy31q/P59ED3MuwphqOGm9l03w==",
-      "dependencies": {
-        "@astrojs/prism": "^3.0.0",
-        "github-slugger": "^2.0.0",
-        "import-meta-resolve": "^3.0.0",
-        "rehype-raw": "^6.1.1",
-        "rehype-stringify": "^9.0.4",
-        "remark-gfm": "^3.0.1",
-        "remark-parse": "^10.0.2",
-        "remark-rehype": "^10.1.0",
-        "remark-smartypants": "^2.0.0",
-        "shiki": "^0.14.3",
-        "unified": "^10.1.2",
-        "unist-util-visit": "^4.1.2",
-        "vfile": "^5.3.7"
-      },
-      "peerDependencies": {
-        "astro": "^3.0.0"
+        "astro": "^3.1.0"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -403,9 +444,9 @@
       }
     },
     "node_modules/@astrojs/vercel": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-4.0.5.tgz",
-      "integrity": "sha512-ANiJt+4ikI188CPqBbVnianBXfe9k0O5mohMMSYqxBuU9Sn9QWYFYz7JtBcirhxDvUhIfbdlRqFXNVcMpOlQrg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-5.0.0.tgz",
+      "integrity": "sha512-EN3g6lRL08Sthrd2HNNi5815XJlmI7ExG7O+rChG3NL+18LzHsMKUrQU70BQLrI1RB6EDuEUb5DofWXqRaWTNg==",
       "dependencies": {
         "@astrojs/internal-helpers": "0.2.0",
         "@vercel/analytics": "^1.0.2",
@@ -416,7 +457,7 @@
         "web-vitals": "^3.4.0"
       },
       "peerDependencies": {
-        "astro": "^3.0.11"
+        "astro": "^3.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -846,9 +887,9 @@
       }
     },
     "node_modules/@edge-runtime/cookies": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/cookies/-/cookies-3.4.0.tgz",
-      "integrity": "sha512-rhkTN7D8YO78lf76gdmK4FYc4Z5zQMGPABFLCWiJzeHmHgaCievF/lHEf1WO1OGZVxe1V34NYxsNTZsXwLht3Q==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/cookies/-/cookies-3.4.1.tgz",
+      "integrity": "sha512-z27BvgPxI73CgSlxU/NAUf1Q/shnqi6cobHEowf6VuLdSjGR3NjI2Y5dZUIBbK2zOJVZbXcHsVzJjz8LklteFQ==",
       "dev": true,
       "engines": {
         "node": ">=16"
@@ -864,33 +905,33 @@
       }
     },
     "node_modules/@edge-runtime/node-utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/node-utils/-/node-utils-2.2.0.tgz",
-      "integrity": "sha512-eRM3d/zwF+VczI9+YY9j0b5s/NQ6Cj6y6XY1Fb3HHdu8rCphH8Z41qjTYt4S315FUXo78GcDgnYv7GUvqQ0a8A==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/node-utils/-/node-utils-2.2.1.tgz",
+      "integrity": "sha512-RUl/439BHKshkhSGFRlZ1kzy68wL4mn8VNKDSZr3p0tciyZ33Mjfpl+vofqnHqXRmDI6nLnZpfJvhY3D88o0pA==",
       "dev": true,
       "dependencies": {
-        "@edge-runtime/cookies": "3.4.0"
+        "@edge-runtime/cookies": "3.4.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@edge-runtime/primitives": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-3.1.0.tgz",
-      "integrity": "sha512-yxr1QM/lC8nrU38zxePeDqVeIjwsJ83gKGTH8YJ4CoHTv3q+6xEeqRIT+/9IPX/FApWYtnxHauhNqr6CHRj5YA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-3.1.1.tgz",
+      "integrity": "sha512-ROO22py+KdAfzqWZu6CtVMC4qV6mS0W1jPI51jGXE+uenyBUN7cQTWB9ReQc8Bm4cnjqmhajvpqEx3j7Y9iSOg==",
       "dev": true,
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@edge-runtime/vm": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.1.0.tgz",
-      "integrity": "sha512-Y2JZgJP+4byI17SiDeEZhvBUvJ+om7E5ll/jrS7aGRpet5qKnJSsGep6xxhMjqT/j8ulFvTMN/kdlMMy5pEKBQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.1.1.tgz",
+      "integrity": "sha512-6NJRRG04/91qnWLZj+wZm27q6fJkTbkZdIJdo/Ig++GTxkAv8Wh/45nIcz9Xg7AzIAMpAkflFdiCrCoZ3hp1Iw==",
       "dev": true,
       "dependencies": {
-        "@edge-runtime/primitives": "3.1.0"
+        "@edge-runtime/primitives": "3.1.1"
       },
       "engines": {
         "node": ">=16"
@@ -1846,9 +1887,9 @@
       }
     },
     "node_modules/@octokit/graphql-schema": {
-      "version": "14.27.2",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql-schema/-/graphql-schema-14.27.2.tgz",
-      "integrity": "sha512-Iczh8dLseBPR4zOUnAZHVWZiHF85PoXy1fXgPzA5hsx72RGpCg78kSyReACOxpIJXTtnFU8rg95bdTPKQSX0Hg==",
+      "version": "14.31.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql-schema/-/graphql-schema-14.31.0.tgz",
+      "integrity": "sha512-OFzXPwFKxXY0hWxH0aECInbKWVrURg38z0X17Gqi1Bbjqjvp3Sm11EAFdBmSFu1idz/UBqPtdEGTXgTF4AfulQ==",
       "dev": true,
       "dependencies": {
         "graphql": "^16.0.0",
@@ -2069,9 +2110,9 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
+      "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
       "dev": true
     },
     "node_modules/@types/json5": {
@@ -2154,9 +2195,9 @@
       "integrity": "sha512-BZFxVrv24VbNNl5xMxqUojQIegEeXMI6rX3rg1uVLYUEXsuKNBSAEQf4BWEcjQDp/8aYJOj6m8V4PUA3x/cxgg=="
     },
     "node_modules/@vercel/build-utils": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-7.1.1.tgz",
-      "integrity": "sha512-JThOdCyvlgH8tLQYvm/yjwPnOrld26MqVObQ75Cm3PjdDpagwNq42Vb7vgqdpOJje7IZCQ2i1vFQIQiTFVIvtw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-7.2.0.tgz",
+      "integrity": "sha512-zLGXMuqRG/s++tqmui6MNRmHHi9phArug6XF5iRLVN8w/w3UxnnMVn3zXmnozrljrjwqSE43u8jLOVDqnk879Q==",
       "dev": true
     },
     "node_modules/@vercel/error-utils": {
@@ -2182,14 +2223,14 @@
       "dev": true
     },
     "node_modules/@vercel/gatsby-plugin-vercel-builder": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.0.4.tgz",
-      "integrity": "sha512-37hkj+xa7U6M0cPXYJc5RZmJhwyVqVKyeGrB4wqr7i4pP4P1wufACPsB0LIVYAfKJkICyulrFzQqsRvnPYHbtw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.0.5.tgz",
+      "integrity": "sha512-NrApRLfSXOs2vJwuX1Hx3vRYM4n+F4LNQgajVW6NAwmWQeKUzfsinA0jduZLYFqpYPeTHXQhbStZL9T4gk8ong==",
       "dev": true,
       "dependencies": {
         "@sinclair/typebox": "0.25.24",
-        "@vercel/build-utils": "7.1.1",
-        "@vercel/node": "3.0.4",
+        "@vercel/build-utils": "7.2.0",
+        "@vercel/node": "3.0.5",
         "@vercel/routing-utils": "3.0.0",
         "esbuild": "0.14.47",
         "etag": "1.8.1",
@@ -2232,21 +2273,25 @@
       }
     },
     "node_modules/@vercel/go": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@vercel/go/-/go-3.0.0.tgz",
-      "integrity": "sha512-haQ7CYbLE9C/UugUSJ89Y10kNxCsE8A1WcLMzWGZA4DJQj7BYdcf8pygB6gpduQFxB8FAiekjUMJGZhRTQkDUw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/go/-/go-3.0.1.tgz",
+      "integrity": "sha512-Bd0jdtNbvAeTadqCOHU5YW7f1nd44WplzETNGvAVijG3c2hDyrKIOQNKzBGyqVaca2HwVqtumxIjTS6rJDkMpA==",
       "dev": true
     },
     "node_modules/@vercel/hydrogen": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@vercel/hydrogen/-/hydrogen-1.0.0.tgz",
-      "integrity": "sha512-hcst/Sml5rFX7U7b2aDNZ6HiQZOahhLTHEuGGS5pV955tFTTO/fQ3gmsIKdjdLwyB69oru1C/bmLbn34QT2xlQ==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/hydrogen/-/hydrogen-1.0.1.tgz",
+      "integrity": "sha512-4PYk4LeIWPTjGtgnxvB0Hdw7aqCau843/96K2xX3z9pa0Hn//pUnZBMz2jrs5MRseCm1Li1LdQAK3u8/vaUnVQ==",
+      "dev": true,
+      "dependencies": {
+        "@vercel/static-config": "3.0.0",
+        "ts-morph": "12.0.0"
+      }
     },
     "node_modules/@vercel/next": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@vercel/next/-/next-4.0.2.tgz",
-      "integrity": "sha512-ulJlIO5ErXy1I1T7WSrku6LuvHsHz6gA1YTB2RbtVYrpWwcqCKrhsdJtvutc7+DReWqwnPtKfxgxzLkLoL5N6Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@vercel/next/-/next-4.0.5.tgz",
+      "integrity": "sha512-wdRiMqfr//KPEzEJYlQ0Ri4SFbPdnoEJdpktdmaxAK7bREvkJeeCjFAkqBDGb1OiqjyKolxF1xwMewRvLj80MQ==",
       "dev": true
     },
     "node_modules/@vercel/nft": {
@@ -2279,21 +2324,21 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/@vercel/node": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-3.0.4.tgz",
-      "integrity": "sha512-HePXFOMZTnuMgUd7x7yj/hxXzMw431ui0ApkBKvtte72Hlquagjz04pjo2nHKms4OREOuHTGsNxsd+MQ5oNfYg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-3.0.5.tgz",
+      "integrity": "sha512-Ow98UMLuODqORNO34j+mbmTGimWD9BjM4onUKkuaSoLaHcl/CAlTTR4m71IdyJeoDBcf0bRURluseED0gmXCTA==",
       "dev": true,
       "dependencies": {
-        "@edge-runtime/node-utils": "2.2.0",
-        "@edge-runtime/primitives": "3.1.0",
-        "@edge-runtime/vm": "3.1.0",
+        "@edge-runtime/node-utils": "2.2.1",
+        "@edge-runtime/primitives": "3.1.1",
+        "@edge-runtime/vm": "3.1.1",
         "@types/node": "14.18.33",
-        "@vercel/build-utils": "7.1.1",
+        "@vercel/build-utils": "7.2.0",
         "@vercel/error-utils": "2.0.1",
         "@vercel/static-config": "3.0.0",
         "async-listen": "3.0.0",
         "content-type": "1.0.5",
-        "edge-runtime": "2.5.0",
+        "edge-runtime": "2.5.1",
         "esbuild": "0.14.47",
         "exit-hook": "2.2.1",
         "node-fetch": "2.6.9",
@@ -2359,15 +2404,15 @@
       }
     },
     "node_modules/@vercel/python": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@vercel/python/-/python-4.0.0.tgz",
-      "integrity": "sha512-BrQhpCLVc7yUl5KwKR/S9wVMTu2g0mKlBYriJ+aewDn7Xf3ZtBl1fZkvKhGihEtLq5Be8xIbCSEEqChLQjfllA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/python/-/python-4.0.1.tgz",
+      "integrity": "sha512-3VfHbLBJ+JIQjUTjosveDM4Y8O6u9vkYWvJYg7BJIyv2TFzJcl8fhW5qurPb5Z7kMj2aRQaN1YRjDvElCOqwVA==",
       "dev": true
     },
     "node_modules/@vercel/redwood": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@vercel/redwood/-/redwood-2.0.1.tgz",
-      "integrity": "sha512-lIgYeOVeCXSsGleAn6/8xZou7nSc2CBQSgNSa1XerX0b/sdhCospq4ianskAxg7sXb9RyfTFAIjCvuFuEgGHmQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@vercel/redwood/-/redwood-2.0.2.tgz",
+      "integrity": "sha512-TyCloruHLi5kBrFPTPDVcQoDDYHG3VfA9ZngNBpqHXQqhR4VsymTh8wV0995faKMPiHcQFbJy7WArhxC/T0Png==",
       "dev": true,
       "dependencies": {
         "@vercel/nft": "0.22.5",
@@ -2416,16 +2461,13 @@
       }
     },
     "node_modules/@vercel/remix-builder": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vercel/remix-builder/-/remix-builder-2.0.3.tgz",
-      "integrity": "sha512-oD+uLMKmZHGca3E4SWLHlunxVSijiOUrHZOaVvqHjYDRsMd6Vw78JR1YlcoBkclHO8yrSbbiiU7SM71j/KDldA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vercel/remix-builder/-/remix-builder-2.0.5.tgz",
+      "integrity": "sha512-EzqyE/B4dNhKYmukOGBDrRl5Z/J7UkX8Q9DXOr0EBR1fs09l+T/qxLshk7rLU2ubl1oDHiIuxOYQWHVb2vtdFw==",
       "dev": true,
       "dependencies": {
-        "@vercel/build-utils": "7.1.1",
         "@vercel/nft": "0.22.5",
         "@vercel/static-config": "3.0.0",
-        "path-to-regexp": "6.2.1",
-        "semver": "7.5.2",
         "ts-morph": "12.0.0"
       }
     },
@@ -2479,19 +2521,19 @@
       "dev": true
     },
     "node_modules/@vercel/ruby": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@vercel/ruby/-/ruby-2.0.1.tgz",
-      "integrity": "sha512-yfbwcLgoV5H70MDhKakRL3ME4iBeXjcxjuQaiBVSQeVx2wfz2p10x933PC0oAHhy3UGGguknOTHr1P8xYPH+8A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@vercel/ruby/-/ruby-2.0.2.tgz",
+      "integrity": "sha512-MqFynhtZ905L210DWAbgkiEQEK39LTtp9eL2Nm6PjzhjNzU6hV0UfK8Z24vU9CC6J4mrUTTZx396fH7XTYJWqg==",
       "dev": true
     },
     "node_modules/@vercel/static-build": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.0.4.tgz",
-      "integrity": "sha512-2uSkLeq7HxZUSLZkOvFIhBar/mSW1Nw2AowAj1t5diAK2HH1ulYFCwNRaXeE7dAHE6X6otvAKgkJPQrTkXwb8g==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.0.6.tgz",
+      "integrity": "sha512-gMqSK+kR8WQupcHXFDnZvpt6z30p1tqRggU68xQP3aI9Spqk6tWT8hXscdPH6OOsQ+fJmis6STc4/4zWZO2WLw==",
       "dev": true,
       "dependencies": {
         "@vercel/gatsby-plugin-vercel-analytics": "1.0.10",
-        "@vercel/gatsby-plugin-vercel-builder": "2.0.4"
+        "@vercel/gatsby-plugin-vercel-builder": "2.0.5"
       }
     },
     "node_modules/@vercel/static-config": {
@@ -2851,13 +2893,13 @@
       }
     },
     "node_modules/astro": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-3.0.12.tgz",
-      "integrity": "sha512-nDLI9OGEjYIX90a1Md1orqyurPxqXTWTy7Sm3ZsWl5dpzSjcUXo3VB/GTvNjAMS9sE40BOxhay7/hnnQuI8p7A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-3.1.0.tgz",
+      "integrity": "sha512-hVPZg9uDafqJbDwOwtcujwhJ6Qp3BCaIj1cvablTYI0jdYrZSvcybhIMTf8NhzK5smvZy2Bv9eEDYXLpiLDrRQ==",
       "dependencies": {
         "@astrojs/compiler": "^2.1.0",
         "@astrojs/internal-helpers": "0.2.0",
-        "@astrojs/markdown-remark": "3.1.0",
+        "@astrojs/markdown-remark": "3.2.0",
         "@astrojs/telemetry": "3.0.1",
         "@babel/core": "^7.22.10",
         "@babel/generator": "^7.22.10",
@@ -2893,6 +2935,7 @@
         "p-limit": "^4.0.0",
         "path-to-regexp": "^6.2.1",
         "preferred-pm": "^3.1.2",
+        "probe-image-size": "^7.2.3",
         "prompts": "^2.4.2",
         "rehype": "^12.0.1",
         "resolve": "^1.22.4",
@@ -3927,13 +3970,13 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/edge-runtime": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/edge-runtime/-/edge-runtime-2.5.0.tgz",
-      "integrity": "sha512-QgDNX6R+RPwhY3+vqHpvYE4XUoB/cFG60nGBKu9pmPOJxQleeTCj2F5CHimIpNqex9h1Cy2Y3tuQ+Vq2GzmZIA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/edge-runtime/-/edge-runtime-2.5.1.tgz",
+      "integrity": "sha512-E0kY1Dqvwvk9yh7dvR56KnCjXf/dlbrrGjO5Sjnz9Ja3WqYT3csv2B8O4erxJiOWfWy9NTukBk4Kb3yrR66gBw==",
       "dev": true,
       "dependencies": {
         "@edge-runtime/format": "2.2.0",
-        "@edge-runtime/vm": "3.1.0",
+        "@edge-runtime/vm": "3.1.1",
         "async-listen": "3.0.1",
         "mri": "1.2.0",
         "picocolors": "1.0.0",
@@ -4631,18 +4674,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fault": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
-      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
-      "dependencies": {
-        "format": "^0.2.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -4681,14 +4712,6 @@
       "dependencies": {
         "micromatch": "^4.0.2",
         "pkg-dir": "^4.2.0"
-      }
-    },
-    "node_modules/format": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
-      "engines": {
-        "node": ">=0.4.x"
       }
     },
     "node_modules/fraction.js": {
@@ -5252,6 +5275,17 @@
         "node": ">=16.17.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -5712,8 +5746,7 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/log-symbols": {
       "version": "5.1.0",
@@ -5899,20 +5932,6 @@
         "micromark-util-types": "^1.0.0",
         "unist-util-stringify-position": "^3.0.0",
         "uvu": "^0.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-frontmatter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-1.0.1.tgz",
-      "integrity": "sha512-JjA2OjxRqAa8wEG8hloD0uTU0kdn8kbtOWpPP94NBkfAlbxn4S8gCGf/9DwFtEeGPXrDcNXdiDjVaRdUFqYokw==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-to-markdown": "^1.3.0",
-        "micromark-extension-frontmatter": "^1.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6196,21 +6215,6 @@
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
         "uvu": "^0.5.0"
-      }
-    },
-    "node_modules/micromark-extension-frontmatter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-1.1.0.tgz",
-      "integrity": "sha512-0nLelmvXR5aZ+F2IL6/Ed4cDnHLpL/VD/EELKuclsTWHrLI8UgxGHEmeoumeX2FXiM6z2WrBIOEcbKUZR8RYNg==",
-      "dependencies": {
-        "fault": "^2.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -7012,6 +7016,30 @@
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
       "optional": true
     },
+    "node_modules/needle": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+      "dependencies": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/needle/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/nlcst-to-string": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-3.1.1.tgz",
@@ -7803,6 +7831,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/probe-image-size": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
+      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
+      "dependencies": {
+        "lodash.merge": "^4.6.2",
+        "needle": "^2.5.2",
+        "stream-parser": "~0.3.1"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -8157,21 +8195,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/remark-frontmatter": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-4.0.1.tgz",
-      "integrity": "sha512-38fJrB0KnmD3E33a5jZC/5+gGAC2WKNiPw1/fdXJvijBlhA7RCsvJklrYJakS0HedninvaCYW8lQGf9C918GfA==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-frontmatter": "^1.0.0",
-        "micromark-extension-frontmatter": "^1.0.0",
-        "unified": "^10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/remark-gfm": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
@@ -8508,6 +8531,11 @@
         }
       ]
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -8834,6 +8862,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
+      "dependencies": {
+        "debug": "2"
+      }
+    },
+    "node_modules/stream-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/stream-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -9682,21 +9731,21 @@
       "devOptional": true
     },
     "node_modules/vercel": {
-      "version": "32.2.0",
-      "resolved": "https://registry.npmjs.org/vercel/-/vercel-32.2.0.tgz",
-      "integrity": "sha512-X/j88AO4p8eOfMbhTXweOxsXgXwixE+SroKNWkuFw+tjMH7nfkHqAFACmiX7J9bymogD7JqPq52kMh4VsmBX7w==",
+      "version": "32.2.4",
+      "resolved": "https://registry.npmjs.org/vercel/-/vercel-32.2.4.tgz",
+      "integrity": "sha512-Vdp/kglvpxcmY+yaQ+4/qZm8O8Hu9sn/JTpdfXNaxAcHP4Pt3GmHTZJmY0K6bQ2MoXjE0/Tp0h9BfHLUoNjRIw==",
       "dev": true,
       "dependencies": {
-        "@vercel/build-utils": "7.1.1",
-        "@vercel/go": "3.0.0",
-        "@vercel/hydrogen": "1.0.0",
-        "@vercel/next": "4.0.2",
-        "@vercel/node": "3.0.4",
-        "@vercel/python": "4.0.0",
-        "@vercel/redwood": "2.0.1",
-        "@vercel/remix-builder": "2.0.3",
-        "@vercel/ruby": "2.0.1",
-        "@vercel/static-build": "2.0.4"
+        "@vercel/build-utils": "7.2.0",
+        "@vercel/go": "3.0.1",
+        "@vercel/hydrogen": "1.0.1",
+        "@vercel/next": "4.0.5",
+        "@vercel/node": "3.0.5",
+        "@vercel/python": "4.0.1",
+        "@vercel/redwood": "2.0.2",
+        "@vercel/remix-builder": "2.0.5",
+        "@vercel/ruby": "2.0.2",
+        "@vercel/static-build": "2.0.6"
       },
       "bin": {
         "vc": "dist/index.js",
@@ -10769,13 +10818,14 @@
       "integrity": "sha512-NQ4ppp1CM0HNkKbJNM4saVSfmUYzGlRalF6wx7F6T/MYHYSWGuojY89/oFTy4t8VlOGUCUijlsVNNeziWaUo5g=="
     },
     "@astrojs/markdown-remark": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-3.1.0.tgz",
-      "integrity": "sha512-5UwamK0iFxN0n1Nw44vUk8AkQr4psKS63hM3D1/4bhhjs4ZFRyrYmg5NjScaMEXZcrd2KgGPsd+PEwNs4mlBOw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-3.2.0.tgz",
+      "integrity": "sha512-jigyLfefUZPKgVmmraCkVpdUuFH1R3SrpgQO13axsgwLDBgkggaQpNR5Ag4O9PDualeBtbdt30aYSfvnBKx9Hg==",
       "requires": {
         "@astrojs/prism": "^3.0.0",
         "github-slugger": "^2.0.0",
         "import-meta-resolve": "^3.0.0",
+        "mdast-util-definitions": "^6.0.0",
         "rehype-raw": "^6.1.1",
         "rehype-stringify": "^9.0.4",
         "remark-gfm": "^3.0.1",
@@ -10786,15 +10836,68 @@
         "unified": "^10.1.2",
         "unist-util-visit": "^4.1.2",
         "vfile": "^5.3.7"
+      },
+      "dependencies": {
+        "@types/mdast": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.0.tgz",
+          "integrity": "sha512-YLeG8CujC9adtj/kuDzq1N4tCDYKoZ5l/bnjq8d74+t/3q/tHquJOJKUQXJrLCflOHpKjXgcI/a929gpmLOEng==",
+          "requires": {
+            "@types/unist": "*"
+          }
+        },
+        "@types/unist": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
+          "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
+        },
+        "mdast-util-definitions": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+          "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+          "requires": {
+            "@types/mdast": "^4.0.0",
+            "@types/unist": "^3.0.0",
+            "unist-util-visit": "^5.0.0"
+          },
+          "dependencies": {
+            "unist-util-visit": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+              "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+              "requires": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+              }
+            }
+          }
+        },
+        "unist-util-is": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+          "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+          "requires": {
+            "@types/unist": "^3.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+          "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-is": "^6.0.0"
+          }
+        }
       }
     },
     "@astrojs/mdx": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-1.0.0.tgz",
-      "integrity": "sha512-Gmeleci8o4X7dST9E85c1+k273zcKW8cSFgZLTwU5K4dC0qHfY/EaDKHWrtzOB2wjZlT1JDRzTJ68LJYGrF2OA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-1.1.0.tgz",
+      "integrity": "sha512-rmLZBw3CUCkp+5blBJloV2EqJGRaJTraJygWMfCvrLcCA3vzhwzACnVQKdUDlts8EEr6V6+HXYVqi46AVEfobg==",
       "requires": {
-        "@astrojs/markdown-remark": "3.0.0",
-        "@astrojs/prism": "3.0.0",
+        "@astrojs/markdown-remark": "3.2.0",
         "@mdx-js/mdx": "^2.3.0",
         "acorn": "^8.10.0",
         "es-module-lexer": "^1.3.0",
@@ -10804,35 +10907,11 @@
         "hast-util-to-html": "^8.0.4",
         "kleur": "^4.1.4",
         "rehype-raw": "^6.1.1",
-        "remark-frontmatter": "^4.0.1",
         "remark-gfm": "^3.0.1",
         "remark-smartypants": "^2.0.0",
-        "shiki": "^0.14.3",
         "source-map": "^0.7.4",
         "unist-util-visit": "^4.1.2",
         "vfile": "^5.3.7"
-      },
-      "dependencies": {
-        "@astrojs/markdown-remark": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-3.0.0.tgz",
-          "integrity": "sha512-s8I49Je4++ImgYAgwL32HgN8m6we2qz3RtBpN4AjObMODPwDylmzUHZksD8Toy31q/P59ED3MuwphqOGm9l03w==",
-          "requires": {
-            "@astrojs/prism": "^3.0.0",
-            "github-slugger": "^2.0.0",
-            "import-meta-resolve": "^3.0.0",
-            "rehype-raw": "^6.1.1",
-            "rehype-stringify": "^9.0.4",
-            "remark-gfm": "^3.0.1",
-            "remark-parse": "^10.0.2",
-            "remark-rehype": "^10.1.0",
-            "remark-smartypants": "^2.0.0",
-            "shiki": "^0.14.3",
-            "unified": "^10.1.2",
-            "unist-util-visit": "^4.1.2",
-            "vfile": "^5.3.7"
-          }
-        }
       }
     },
     "@astrojs/prism": {
@@ -10887,9 +10966,9 @@
       }
     },
     "@astrojs/vercel": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-4.0.5.tgz",
-      "integrity": "sha512-ANiJt+4ikI188CPqBbVnianBXfe9k0O5mohMMSYqxBuU9Sn9QWYFYz7JtBcirhxDvUhIfbdlRqFXNVcMpOlQrg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-5.0.0.tgz",
+      "integrity": "sha512-EN3g6lRL08Sthrd2HNNi5815XJlmI7ExG7O+rChG3NL+18LzHsMKUrQU70BQLrI1RB6EDuEUb5DofWXqRaWTNg==",
       "requires": {
         "@astrojs/internal-helpers": "0.2.0",
         "@vercel/analytics": "^1.0.2",
@@ -11212,9 +11291,9 @@
       }
     },
     "@edge-runtime/cookies": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/cookies/-/cookies-3.4.0.tgz",
-      "integrity": "sha512-rhkTN7D8YO78lf76gdmK4FYc4Z5zQMGPABFLCWiJzeHmHgaCievF/lHEf1WO1OGZVxe1V34NYxsNTZsXwLht3Q==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/cookies/-/cookies-3.4.1.tgz",
+      "integrity": "sha512-z27BvgPxI73CgSlxU/NAUf1Q/shnqi6cobHEowf6VuLdSjGR3NjI2Y5dZUIBbK2zOJVZbXcHsVzJjz8LklteFQ==",
       "dev": true
     },
     "@edge-runtime/format": {
@@ -11224,27 +11303,27 @@
       "dev": true
     },
     "@edge-runtime/node-utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/node-utils/-/node-utils-2.2.0.tgz",
-      "integrity": "sha512-eRM3d/zwF+VczI9+YY9j0b5s/NQ6Cj6y6XY1Fb3HHdu8rCphH8Z41qjTYt4S315FUXo78GcDgnYv7GUvqQ0a8A==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/node-utils/-/node-utils-2.2.1.tgz",
+      "integrity": "sha512-RUl/439BHKshkhSGFRlZ1kzy68wL4mn8VNKDSZr3p0tciyZ33Mjfpl+vofqnHqXRmDI6nLnZpfJvhY3D88o0pA==",
       "dev": true,
       "requires": {
-        "@edge-runtime/cookies": "3.4.0"
+        "@edge-runtime/cookies": "3.4.1"
       }
     },
     "@edge-runtime/primitives": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-3.1.0.tgz",
-      "integrity": "sha512-yxr1QM/lC8nrU38zxePeDqVeIjwsJ83gKGTH8YJ4CoHTv3q+6xEeqRIT+/9IPX/FApWYtnxHauhNqr6CHRj5YA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-3.1.1.tgz",
+      "integrity": "sha512-ROO22py+KdAfzqWZu6CtVMC4qV6mS0W1jPI51jGXE+uenyBUN7cQTWB9ReQc8Bm4cnjqmhajvpqEx3j7Y9iSOg==",
       "dev": true
     },
     "@edge-runtime/vm": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.1.0.tgz",
-      "integrity": "sha512-Y2JZgJP+4byI17SiDeEZhvBUvJ+om7E5ll/jrS7aGRpet5qKnJSsGep6xxhMjqT/j8ulFvTMN/kdlMMy5pEKBQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.1.1.tgz",
+      "integrity": "sha512-6NJRRG04/91qnWLZj+wZm27q6fJkTbkZdIJdo/Ig++GTxkAv8Wh/45nIcz9Xg7AzIAMpAkflFdiCrCoZ3hp1Iw==",
       "dev": true,
       "requires": {
-        "@edge-runtime/primitives": "3.1.0"
+        "@edge-runtime/primitives": "3.1.1"
       }
     },
     "@esbuild-kit/cjs-loader": {
@@ -11752,9 +11831,9 @@
       }
     },
     "@octokit/graphql-schema": {
-      "version": "14.27.2",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql-schema/-/graphql-schema-14.27.2.tgz",
-      "integrity": "sha512-Iczh8dLseBPR4zOUnAZHVWZiHF85PoXy1fXgPzA5hsx72RGpCg78kSyReACOxpIJXTtnFU8rg95bdTPKQSX0Hg==",
+      "version": "14.31.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql-schema/-/graphql-schema-14.31.0.tgz",
+      "integrity": "sha512-OFzXPwFKxXY0hWxH0aECInbKWVrURg38z0X17Gqi1Bbjqjvp3Sm11EAFdBmSFu1idz/UBqPtdEGTXgTF4AfulQ==",
       "dev": true,
       "requires": {
         "graphql": "^16.0.0",
@@ -11964,9 +12043,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
+      "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
       "dev": true
     },
     "@types/json5": {
@@ -12049,9 +12128,9 @@
       "integrity": "sha512-BZFxVrv24VbNNl5xMxqUojQIegEeXMI6rX3rg1uVLYUEXsuKNBSAEQf4BWEcjQDp/8aYJOj6m8V4PUA3x/cxgg=="
     },
     "@vercel/build-utils": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-7.1.1.tgz",
-      "integrity": "sha512-JThOdCyvlgH8tLQYvm/yjwPnOrld26MqVObQ75Cm3PjdDpagwNq42Vb7vgqdpOJje7IZCQ2i1vFQIQiTFVIvtw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-7.2.0.tgz",
+      "integrity": "sha512-zLGXMuqRG/s++tqmui6MNRmHHi9phArug6XF5iRLVN8w/w3UxnnMVn3zXmnozrljrjwqSE43u8jLOVDqnk879Q==",
       "dev": true
     },
     "@vercel/error-utils": {
@@ -12079,14 +12158,14 @@
       }
     },
     "@vercel/gatsby-plugin-vercel-builder": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.0.4.tgz",
-      "integrity": "sha512-37hkj+xa7U6M0cPXYJc5RZmJhwyVqVKyeGrB4wqr7i4pP4P1wufACPsB0LIVYAfKJkICyulrFzQqsRvnPYHbtw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.0.5.tgz",
+      "integrity": "sha512-NrApRLfSXOs2vJwuX1Hx3vRYM4n+F4LNQgajVW6NAwmWQeKUzfsinA0jduZLYFqpYPeTHXQhbStZL9T4gk8ong==",
       "dev": true,
       "requires": {
         "@sinclair/typebox": "0.25.24",
-        "@vercel/build-utils": "7.1.1",
-        "@vercel/node": "3.0.4",
+        "@vercel/build-utils": "7.2.0",
+        "@vercel/node": "3.0.5",
         "@vercel/routing-utils": "3.0.0",
         "esbuild": "0.14.47",
         "etag": "1.8.1",
@@ -12124,21 +12203,25 @@
       }
     },
     "@vercel/go": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@vercel/go/-/go-3.0.0.tgz",
-      "integrity": "sha512-haQ7CYbLE9C/UugUSJ89Y10kNxCsE8A1WcLMzWGZA4DJQj7BYdcf8pygB6gpduQFxB8FAiekjUMJGZhRTQkDUw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/go/-/go-3.0.1.tgz",
+      "integrity": "sha512-Bd0jdtNbvAeTadqCOHU5YW7f1nd44WplzETNGvAVijG3c2hDyrKIOQNKzBGyqVaca2HwVqtumxIjTS6rJDkMpA==",
       "dev": true
     },
     "@vercel/hydrogen": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@vercel/hydrogen/-/hydrogen-1.0.0.tgz",
-      "integrity": "sha512-hcst/Sml5rFX7U7b2aDNZ6HiQZOahhLTHEuGGS5pV955tFTTO/fQ3gmsIKdjdLwyB69oru1C/bmLbn34QT2xlQ==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/hydrogen/-/hydrogen-1.0.1.tgz",
+      "integrity": "sha512-4PYk4LeIWPTjGtgnxvB0Hdw7aqCau843/96K2xX3z9pa0Hn//pUnZBMz2jrs5MRseCm1Li1LdQAK3u8/vaUnVQ==",
+      "dev": true,
+      "requires": {
+        "@vercel/static-config": "3.0.0",
+        "ts-morph": "12.0.0"
+      }
     },
     "@vercel/next": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@vercel/next/-/next-4.0.2.tgz",
-      "integrity": "sha512-ulJlIO5ErXy1I1T7WSrku6LuvHsHz6gA1YTB2RbtVYrpWwcqCKrhsdJtvutc7+DReWqwnPtKfxgxzLkLoL5N6Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@vercel/next/-/next-4.0.5.tgz",
+      "integrity": "sha512-wdRiMqfr//KPEzEJYlQ0Ri4SFbPdnoEJdpktdmaxAK7bREvkJeeCjFAkqBDGb1OiqjyKolxF1xwMewRvLj80MQ==",
       "dev": true
     },
     "@vercel/nft": {
@@ -12167,21 +12250,21 @@
       }
     },
     "@vercel/node": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-3.0.4.tgz",
-      "integrity": "sha512-HePXFOMZTnuMgUd7x7yj/hxXzMw431ui0ApkBKvtte72Hlquagjz04pjo2nHKms4OREOuHTGsNxsd+MQ5oNfYg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-3.0.5.tgz",
+      "integrity": "sha512-Ow98UMLuODqORNO34j+mbmTGimWD9BjM4onUKkuaSoLaHcl/CAlTTR4m71IdyJeoDBcf0bRURluseED0gmXCTA==",
       "dev": true,
       "requires": {
-        "@edge-runtime/node-utils": "2.2.0",
-        "@edge-runtime/primitives": "3.1.0",
-        "@edge-runtime/vm": "3.1.0",
+        "@edge-runtime/node-utils": "2.2.1",
+        "@edge-runtime/primitives": "3.1.1",
+        "@edge-runtime/vm": "3.1.1",
         "@types/node": "14.18.33",
-        "@vercel/build-utils": "7.1.1",
+        "@vercel/build-utils": "7.2.0",
         "@vercel/error-utils": "2.0.1",
         "@vercel/static-config": "3.0.0",
         "async-listen": "3.0.0",
         "content-type": "1.0.5",
-        "edge-runtime": "2.5.0",
+        "edge-runtime": "2.5.1",
         "esbuild": "0.14.47",
         "exit-hook": "2.2.1",
         "node-fetch": "2.6.9",
@@ -12235,15 +12318,15 @@
       }
     },
     "@vercel/python": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@vercel/python/-/python-4.0.0.tgz",
-      "integrity": "sha512-BrQhpCLVc7yUl5KwKR/S9wVMTu2g0mKlBYriJ+aewDn7Xf3ZtBl1fZkvKhGihEtLq5Be8xIbCSEEqChLQjfllA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/python/-/python-4.0.1.tgz",
+      "integrity": "sha512-3VfHbLBJ+JIQjUTjosveDM4Y8O6u9vkYWvJYg7BJIyv2TFzJcl8fhW5qurPb5Z7kMj2aRQaN1YRjDvElCOqwVA==",
       "dev": true
     },
     "@vercel/redwood": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@vercel/redwood/-/redwood-2.0.1.tgz",
-      "integrity": "sha512-lIgYeOVeCXSsGleAn6/8xZou7nSc2CBQSgNSa1XerX0b/sdhCospq4ianskAxg7sXb9RyfTFAIjCvuFuEgGHmQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@vercel/redwood/-/redwood-2.0.2.tgz",
+      "integrity": "sha512-TyCloruHLi5kBrFPTPDVcQoDDYHG3VfA9ZngNBpqHXQqhR4VsymTh8wV0995faKMPiHcQFbJy7WArhxC/T0Png==",
       "dev": true,
       "requires": {
         "@vercel/nft": "0.22.5",
@@ -12285,16 +12368,13 @@
       }
     },
     "@vercel/remix-builder": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vercel/remix-builder/-/remix-builder-2.0.3.tgz",
-      "integrity": "sha512-oD+uLMKmZHGca3E4SWLHlunxVSijiOUrHZOaVvqHjYDRsMd6Vw78JR1YlcoBkclHO8yrSbbiiU7SM71j/KDldA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vercel/remix-builder/-/remix-builder-2.0.5.tgz",
+      "integrity": "sha512-EzqyE/B4dNhKYmukOGBDrRl5Z/J7UkX8Q9DXOr0EBR1fs09l+T/qxLshk7rLU2ubl1oDHiIuxOYQWHVb2vtdFw==",
       "dev": true,
       "requires": {
-        "@vercel/build-utils": "7.1.1",
         "@vercel/nft": "0.22.5",
         "@vercel/static-config": "3.0.0",
-        "path-to-regexp": "6.2.1",
-        "semver": "7.5.2",
         "ts-morph": "12.0.0"
       },
       "dependencies": {
@@ -12344,19 +12424,19 @@
       }
     },
     "@vercel/ruby": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@vercel/ruby/-/ruby-2.0.1.tgz",
-      "integrity": "sha512-yfbwcLgoV5H70MDhKakRL3ME4iBeXjcxjuQaiBVSQeVx2wfz2p10x933PC0oAHhy3UGGguknOTHr1P8xYPH+8A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@vercel/ruby/-/ruby-2.0.2.tgz",
+      "integrity": "sha512-MqFynhtZ905L210DWAbgkiEQEK39LTtp9eL2Nm6PjzhjNzU6hV0UfK8Z24vU9CC6J4mrUTTZx396fH7XTYJWqg==",
       "dev": true
     },
     "@vercel/static-build": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.0.4.tgz",
-      "integrity": "sha512-2uSkLeq7HxZUSLZkOvFIhBar/mSW1Nw2AowAj1t5diAK2HH1ulYFCwNRaXeE7dAHE6X6otvAKgkJPQrTkXwb8g==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.0.6.tgz",
+      "integrity": "sha512-gMqSK+kR8WQupcHXFDnZvpt6z30p1tqRggU68xQP3aI9Spqk6tWT8hXscdPH6OOsQ+fJmis6STc4/4zWZO2WLw==",
       "dev": true,
       "requires": {
         "@vercel/gatsby-plugin-vercel-analytics": "1.0.10",
-        "@vercel/gatsby-plugin-vercel-builder": "2.0.4"
+        "@vercel/gatsby-plugin-vercel-builder": "2.0.5"
       }
     },
     "@vercel/static-config": {
@@ -12639,13 +12719,13 @@
       "integrity": "sha512-97a+l2LBU3Op3bBQEff79i/E4jMD2ZLFD8rHx9B6mXyB2uQwhJQYfiDqUwtfjF4QA1F2qs//N6Cw8LetMbQjcw=="
     },
     "astro": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-3.0.12.tgz",
-      "integrity": "sha512-nDLI9OGEjYIX90a1Md1orqyurPxqXTWTy7Sm3ZsWl5dpzSjcUXo3VB/GTvNjAMS9sE40BOxhay7/hnnQuI8p7A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-3.1.0.tgz",
+      "integrity": "sha512-hVPZg9uDafqJbDwOwtcujwhJ6Qp3BCaIj1cvablTYI0jdYrZSvcybhIMTf8NhzK5smvZy2Bv9eEDYXLpiLDrRQ==",
       "requires": {
         "@astrojs/compiler": "^2.1.0",
         "@astrojs/internal-helpers": "0.2.0",
-        "@astrojs/markdown-remark": "3.1.0",
+        "@astrojs/markdown-remark": "3.2.0",
         "@astrojs/telemetry": "3.0.1",
         "@babel/core": "^7.22.10",
         "@babel/generator": "^7.22.10",
@@ -12681,6 +12761,7 @@
         "p-limit": "^4.0.0",
         "path-to-regexp": "^6.2.1",
         "preferred-pm": "^3.1.2",
+        "probe-image-size": "^7.2.3",
         "prompts": "^2.4.2",
         "rehype": "^12.0.1",
         "resolve": "^1.22.4",
@@ -13367,13 +13448,13 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "edge-runtime": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/edge-runtime/-/edge-runtime-2.5.0.tgz",
-      "integrity": "sha512-QgDNX6R+RPwhY3+vqHpvYE4XUoB/cFG60nGBKu9pmPOJxQleeTCj2F5CHimIpNqex9h1Cy2Y3tuQ+Vq2GzmZIA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/edge-runtime/-/edge-runtime-2.5.1.tgz",
+      "integrity": "sha512-E0kY1Dqvwvk9yh7dvR56KnCjXf/dlbrrGjO5Sjnz9Ja3WqYT3csv2B8O4erxJiOWfWy9NTukBk4Kb3yrR66gBw==",
       "dev": true,
       "requires": {
         "@edge-runtime/format": "2.2.0",
-        "@edge-runtime/vm": "3.1.0",
+        "@edge-runtime/vm": "3.1.1",
         "async-listen": "3.0.1",
         "mri": "1.2.0",
         "picocolors": "1.0.0",
@@ -13797,14 +13878,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "fault": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
-      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
-      "requires": {
-        "format": "^0.2.0"
-      }
-    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -13835,11 +13908,6 @@
         "micromatch": "^4.0.2",
         "pkg-dir": "^4.2.0"
       }
-    },
-    "format": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="
     },
     "fraction.js": {
       "version": "4.2.0",
@@ -14267,6 +14335,14 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
       "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="
     },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -14568,8 +14644,7 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "log-symbols": {
       "version": "5.1.0",
@@ -14711,16 +14786,6 @@
         "micromark-util-types": "^1.0.0",
         "unist-util-stringify-position": "^3.0.0",
         "uvu": "^0.5.0"
-      }
-    },
-    "mdast-util-frontmatter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-1.0.1.tgz",
-      "integrity": "sha512-JjA2OjxRqAa8wEG8hloD0uTU0kdn8kbtOWpPP94NBkfAlbxn4S8gCGf/9DwFtEeGPXrDcNXdiDjVaRdUFqYokw==",
-      "requires": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-to-markdown": "^1.3.0",
-        "micromark-extension-frontmatter": "^1.0.0"
       }
     },
     "mdast-util-gfm": {
@@ -14933,17 +14998,6 @@
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
         "uvu": "^0.5.0"
-      }
-    },
-    "micromark-extension-frontmatter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-1.1.0.tgz",
-      "integrity": "sha512-0nLelmvXR5aZ+F2IL6/Ed4cDnHLpL/VD/EELKuclsTWHrLI8UgxGHEmeoumeX2FXiM6z2WrBIOEcbKUZR8RYNg==",
-      "requires": {
-        "fault": "^2.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
       }
     },
     "micromark-extension-gfm": {
@@ -15423,6 +15477,26 @@
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
       "optional": true
+    },
+    "needle": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "nlcst-to-string": {
       "version": "3.1.1",
@@ -15957,6 +16031,16 @@
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
       "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
     },
+    "probe-image-size": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
+      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
+      "requires": {
+        "lodash.merge": "^4.6.2",
+        "needle": "^2.5.2",
+        "stream-parser": "~0.3.1"
+      }
+    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -16227,17 +16311,6 @@
         "unified": "^10.0.0"
       }
     },
-    "remark-frontmatter": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-4.0.1.tgz",
-      "integrity": "sha512-38fJrB0KnmD3E33a5jZC/5+gGAC2WKNiPw1/fdXJvijBlhA7RCsvJklrYJakS0HedninvaCYW8lQGf9C918GfA==",
-      "requires": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-frontmatter": "^1.0.0",
-        "micromark-extension-frontmatter": "^1.0.0",
-        "unified": "^10.0.0"
-      }
-    },
     "remark-gfm": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
@@ -16459,6 +16532,11 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sax": {
       "version": "1.2.4",
@@ -16702,6 +16780,29 @@
       "integrity": "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==",
       "requires": {
         "bl": "^5.0.0"
+      }
+    },
+    "stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
+      "requires": {
+        "debug": "2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        }
       }
     },
     "streamsearch": {
@@ -17313,21 +17414,21 @@
       "devOptional": true
     },
     "vercel": {
-      "version": "32.2.0",
-      "resolved": "https://registry.npmjs.org/vercel/-/vercel-32.2.0.tgz",
-      "integrity": "sha512-X/j88AO4p8eOfMbhTXweOxsXgXwixE+SroKNWkuFw+tjMH7nfkHqAFACmiX7J9bymogD7JqPq52kMh4VsmBX7w==",
+      "version": "32.2.4",
+      "resolved": "https://registry.npmjs.org/vercel/-/vercel-32.2.4.tgz",
+      "integrity": "sha512-Vdp/kglvpxcmY+yaQ+4/qZm8O8Hu9sn/JTpdfXNaxAcHP4Pt3GmHTZJmY0K6bQ2MoXjE0/Tp0h9BfHLUoNjRIw==",
       "dev": true,
       "requires": {
-        "@vercel/build-utils": "7.1.1",
-        "@vercel/go": "3.0.0",
-        "@vercel/hydrogen": "1.0.0",
-        "@vercel/next": "4.0.2",
-        "@vercel/node": "3.0.4",
-        "@vercel/python": "4.0.0",
-        "@vercel/redwood": "2.0.1",
-        "@vercel/remix-builder": "2.0.3",
-        "@vercel/ruby": "2.0.1",
-        "@vercel/static-build": "2.0.4"
+        "@vercel/build-utils": "7.2.0",
+        "@vercel/go": "3.0.1",
+        "@vercel/hydrogen": "1.0.1",
+        "@vercel/next": "4.0.5",
+        "@vercel/node": "3.0.5",
+        "@vercel/python": "4.0.1",
+        "@vercel/redwood": "2.0.2",
+        "@vercel/remix-builder": "2.0.5",
+        "@vercel/ruby": "2.0.2",
+        "@vercel/static-build": "2.0.6"
       }
     },
     "vfile": {

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "update:showcase": "tsx scripts/update-showcase.ts"
   },
   "dependencies": {
-    "@astrojs/markdown-remark": "^3.1.0",
-    "@astrojs/mdx": "^1.0.0",
+    "@astrojs/markdown-remark": "^3.2.0",
+    "@astrojs/mdx": "^1.1.0",
     "@astrojs/rss": "^3.0.0",
     "@astrojs/sitemap": "^3.0.0",
     "@astrojs/tailwind": "^5.0.0",
-    "@astrojs/vercel": "^4.0.5",
+    "@astrojs/vercel": "^5.0.0",
     "@vercel/analytics": "^1.0.2",
-    "astro": "^3.0.8",
+    "astro": "^3.1.0",
     "daisyui": "^3.7.5",
     "gemoji": "^8.1.0",
     "tailwindcss": "^3.3.3",
@@ -31,7 +31,7 @@
     "@docsearch/js": "^3.5.2",
     "@faker-js/faker": "8.0.2",
     "@octokit/graphql": "^7.0.1",
-    "@octokit/graphql-schema": "^14.27.2",
+    "@octokit/graphql-schema": "^14.31.0",
     "@tailwindcss/typography": "^0.5.9",
     "@types/parse-github-url": "^1.0.0",
     "dotenv": "^16.3.1",
@@ -40,7 +40,7 @@
     "reading-time": "^1.5.0",
     "rehype-autolink-headings": "^7.0.0",
     "tsx": "^3.12.8",
-    "vercel": "^32.2.0",
+    "vercel": "^32.2.4",
     "vitest": "^0.34.3"
   }
 }


### PR DESCRIPTION
- `@astrojs/markdown-remark`: 3.1.0→ 3.2.0
- `@astrojs/mdx`: 1.0.0 → 1.1.0
- `@astrojs/vercel`: 4.0.5 → 5.0.0
- `astro`: 3.0.8 → 3.1.0
- `@octokit/graphql-schema`: 14.27.2 → 14.31.0
- `vercel`: 32.2.0 → 32.2.4
