### PR TITLE
feat: unify meta descriptions and descriptions in guide

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -38,8 +38,7 @@ const modulesCollection = defineCollection({
   schema: z.object({
     id: z.number(),
     creationDate: z.string().optional(),
-    description: z.string().optional(),
-    metaDescription: z.string(),
+    description: z.string(),
     lastUpdateDate: z.string().optional(),
     title: z.string(),
     soon: z.boolean().optional(),

--- a/src/content/modules/contributing-to-open-source-projects/building-a-portfolio-with-open-source-contributions.mdx
+++ b/src/content/modules/contributing-to-open-source-projects/building-a-portfolio-with-open-source-contributions.mdx
@@ -1,7 +1,7 @@
 ---
 id: 4
 title: 'Building a Portfolio with Open Source Contributions'
-metaDescription: 'Boost your portfolio with Open Source contributions. Showcase your skills, expertise and commitment. Learn how to highlight contributions effectively here.'
+description: 'Boost your portfolio with Open Source contributions. Showcase your skills, expertise and commitment. Learn how to highlight contributions effectively here.'
 creationDate: '2023-04-08'
 lastUpdateDate: '2023-04-08'
 ---

--- a/src/content/modules/contributing-to-open-source-projects/contributing-to-open-source.mdx
+++ b/src/content/modules/contributing-to-open-source-projects/contributing-to-open-source.mdx
@@ -1,7 +1,7 @@
 ---
 id: 2
 title: 'Contributing to Open Source'
-metaDescription: 'Connect, learn and give back to Open Source by contributing. Learn ways to contribute, best practices, and submitting a Pull Request. Start today!'
+description: 'Connect, learn and give back to Open Source by contributing. Learn ways to contribute, best practices, and submitting a Pull Request. Start today!'
 creationDate: '2023-04-08'
 lastUpdateDate: '2023-04-08'
 ---

--- a/src/content/modules/contributing-to-open-source-projects/finding-open-source-projects.mdx
+++ b/src/content/modules/contributing-to-open-source-projects/finding-open-source-projects.mdx
@@ -1,7 +1,7 @@
 ---
 id: 1
 title: 'Finding Open Source Projects'
-metaDescription: 'Find the perfect Open Source project to learn new skills and collaborate with developers. Explore ways to find projects aligned with your interests. Start today!'
+description: 'Find the perfect Open Source project to learn new skills and collaborate with developers. Explore ways to find projects aligned with your interests. Start today!'
 creationDate: '2023-04-06'
 lastUpdateDate: '2023-04-08'
 ---

--- a/src/content/modules/contributing-to-open-source-projects/getting-involved-in-the-open-source-community.mdx
+++ b/src/content/modules/contributing-to-open-source-projects/getting-involved-in-the-open-source-community.mdx
@@ -1,7 +1,7 @@
 ---
 id: 3
 title: 'Getting Involved in the Open Source Community'
-metaDescription: 'Join the collaborative Open Source community, build skills, make connections, and contribute to a cause. Learn to get involved, communicate, and participate in events. Join now!'
+description: 'Join the collaborative Open Source community, build skills, make connections, and contribute to a cause. Learn to get involved, communicate, and participate in events. Join now!'
 creationDate: '2023-04-08'
 lastUpdateDate: '2023-04-08'
 ---

--- a/src/content/modules/contributing-to-open-source-projects/index.mdx
+++ b/src/content/modules/contributing-to-open-source-projects/index.mdx
@@ -2,7 +2,6 @@
 id: 3
 title: 'Contributing to Open Source Projects'
 description: 'Start contributing to Open Source projects today! Learn the basics of finding the right project and following community guidelines to make a meaningful impact in the Open Source community.'
-metaDescription: 'Begin your Open Source contribution today! Discover benefits and learn to find the right project, follow guidelines, and make an impact. Start now!'
 ---
 <p class="lead">Discover the benefits of contributing to Open Source projects and learn how to get started today. This module will equip you with the essential knowledge to find the right project, follow community guidelines, and make a meaningful impact in the Open Source community.</p>
         

--- a/src/content/modules/contributing-to-open-source-projects/overcoming-challenges-in-open-source-contributions.mdx
+++ b/src/content/modules/contributing-to-open-source-projects/overcoming-challenges-in-open-source-contributions.mdx
@@ -1,7 +1,7 @@
 ---
 id: 5
 title: 'Overcoming Challenges in Open Source Contributions'
-metaDescription: 'Overcome common challenges in Open Source contribution and maintain work/Open Source/life balance. Learn to tackle imposter syndrome, burnout and communication barriers. Start contributing sustainably today!'
+description: 'Overcome common challenges in Open Source contribution and maintain work/Open Source/life balance. Learn to tackle imposter syndrome, burnout and communication barriers. Start contributing sustainably today!'
 creationDate: '2023-04-08'
 lastUpdateDate: '2023-04-08'
 ---

--- a/src/content/modules/creating-your-own-open-source-project/building-and-engaging-your-community.mdx
+++ b/src/content/modules/creating-your-own-open-source-project/building-and-engaging-your-community.mdx
@@ -1,6 +1,6 @@
 ---
 id: 5
 title: 'Building and Engaging Your Community'
-metaDescription: ""
+description: ""
 soon: true
 ---

--- a/src/content/modules/creating-your-own-open-source-project/choosing-a-project-idea.mdx
+++ b/src/content/modules/creating-your-own-open-source-project/choosing-a-project-idea.mdx
@@ -1,7 +1,7 @@
 ---
 id: 1
 title: 'Choosing a Project Idea'
-metaDescription: 'Select your ideal Open Source project with ease. Learn to evaluate feasibility, impact and research existing projects. Make a positive impact with your skills!'
+description: 'Select your ideal Open Source project with ease. Learn to evaluate feasibility, impact and research existing projects. Make a positive impact with your skills!'
 creationDate: '2023-04-09'
 lastUpdateDate: '2023-04-09'
 ---

--- a/src/content/modules/creating-your-own-open-source-project/contributing-your-project-to-the-open-source-community.mdx
+++ b/src/content/modules/creating-your-own-open-source-project/contributing-your-project-to-the-open-source-community.mdx
@@ -1,6 +1,6 @@
 ---
 id: 6
 title: 'Contributing Your Project to the Open Source Community'
-metaDescription: ""
+description: ""
 soon: true
 ---

--- a/src/content/modules/creating-your-own-open-source-project/creating-your-project.mdx
+++ b/src/content/modules/creating-your-own-open-source-project/creating-your-project.mdx
@@ -1,7 +1,7 @@
 ---
 id: 3
 title: 'Creating Your Project'
-metaDescription: "Ready to bring your Open Source project idea to life? Learn to create a project repository on GitHub or GitLab and start shaping your impact on the Open Source world."
+description: "Ready to bring your Open Source project idea to life? Learn to create a project repository on GitHub or GitLab and start shaping your impact on the Open Source world."
 creationDate: '2023-10-14'
 lastUpdateDate: '2023-10-14'
 ---

--- a/src/content/modules/creating-your-own-open-source-project/developing-your-project.mdx
+++ b/src/content/modules/creating-your-own-open-source-project/developing-your-project.mdx
@@ -1,6 +1,6 @@
 ---
 id: 4
 title: 'Developing Your Project'
-metaDescription: ""
+description: ""
 soon: true
 ---

--- a/src/content/modules/creating-your-own-open-source-project/index.mdx
+++ b/src/content/modules/creating-your-own-open-source-project/index.mdx
@@ -2,7 +2,6 @@
 id: 4
 title: 'Creating Your Own Open Source Project'
 description: 'Learn how to create and contribute to your own Open Source project by choosing an idea, planning, developing, and building a community with this comprehensive guide.'
-metaDescription: 'Create and contribute to your Open Source project with ease. This module guides from idea to community building. Start your rewarding journey today!'
 ---
 <p class="lead">Creating your own Open Source project can be an exciting and rewarding experience, but it can also be challenging without proper guidance. In this module, you will learn how to create and contribute to your own Open Source project, from choosing the idea to building a community and making it accessible to the world.</p>
         

--- a/src/content/modules/creating-your-own-open-source-project/legal-considerations.mdx
+++ b/src/content/modules/creating-your-own-open-source-project/legal-considerations.mdx
@@ -1,6 +1,6 @@
 ---
 id: 7
 title: 'Legal Considerations'
-metaDescription: ""
+description: ""
 soon: true
 ---

--- a/src/content/modules/creating-your-own-open-source-project/planning-your-project.mdx
+++ b/src/content/modules/creating-your-own-open-source-project/planning-your-project.mdx
@@ -1,7 +1,7 @@
 ---
 id: 2
 title: 'Planning Your Project'
-metaDescription: "Learn about the crucial role of planning in creating a successful Open Source project and how to identify your target audience and goals. While there's no one-size-fits-all approach, this chapter provides key insights to help you get started."
+description: "Learn about the crucial role of planning in creating a successful Open Source project and how to identify your target audience and goals. While there's no one-size-fits-all approach, this chapter provides key insights to help you get started."
 creationDate: '2023-04-16'
 lastUpdateDate: '2023-04-16'
 ---

--- a/src/content/modules/financing-open-source-projects/index.mdx
+++ b/src/content/modules/financing-open-source-projects/index.mdx
@@ -2,7 +2,6 @@
 id: 7
 title: 'Financing Open Source Projects'
 description: 'Discover sustainable funding models and strategies to finance your Open Source projects. Empower your project''s growth and long-term viability.'
-metaDescription: 'Discover sustainable funding models and strategies to finance your Open Source projects. Empower your project''s growth and long-term viability.'
 ---
 <p class="lead">Financing Open Source projects can be challenging. In this module, we will delve into the crucial aspect of financing Open Source projects and explore sustainable funding models and strategies that can empower the growth and long-term viability of your projects.</p>
 

--- a/src/content/modules/getting-started-with-open-source/finding-open-source-projects.mdx
+++ b/src/content/modules/getting-started-with-open-source/finding-open-source-projects.mdx
@@ -1,7 +1,7 @@
 ---
 id: 2
 title: 'Finding Open Source Projects'
-metaDescription: 'Easily find Open Source projects on platforms like GitHub and GitLab. Explore curated lists and directories to discover exciting projects.'
+description: 'Easily find Open Source projects on platforms like GitHub and GitLab. Explore curated lists and directories to discover exciting projects.'
 creationDate: '2023-06-04'
 lastUpdateDate: '2023-06-04'
 ---

--- a/src/content/modules/getting-started-with-open-source/index.mdx
+++ b/src/content/modules/getting-started-with-open-source/index.mdx
@@ -2,7 +2,6 @@
 id: 2
 title: 'Getting Started With Open Source'
 description: 'Discover the fundamentals of Open Source and unlock its benefits! Explore the vibrant world of collaborative projects and find your perfect fit.'
-metaDescription: 'Discover the fundamentals of Open Source and unlock its benefits! Explore the vibrant world of collaborative projects and find your perfect fit.'
 ---
 <p class="lead">Now that we know what we are talking about, let’s dive into the world of Open Source!</p>
         

--- a/src/content/modules/getting-started-with-open-source/source-code-hosting-platforms.mdx
+++ b/src/content/modules/getting-started-with-open-source/source-code-hosting-platforms.mdx
@@ -1,7 +1,7 @@
 ---
 id: 1
 title: 'Source Code Hosting Platforms'
-metaDescription: 'Discover top source code hosting platforms like GitHub and GitLab for hosting and collaborating on Open Source projects.'
+description: 'Discover top source code hosting platforms like GitHub and GitLab for hosting and collaborating on Open Source projects.'
 creationDate: '2023-06-04'
 lastUpdateDate: '2023-06-04'
 ---

--- a/src/content/modules/maintaining-open-source-projects/ensuring-project-sustainability.mdx
+++ b/src/content/modules/maintaining-open-source-projects/ensuring-project-sustainability.mdx
@@ -1,6 +1,6 @@
 ---
 id: 6
 title: 'Ensuring Project Sustainability'
-metaDescription: ""
+description: ""
 soon: true
 ---

--- a/src/content/modules/maintaining-open-source-projects/fostering-a-strong-and-inclusive-community.mdx
+++ b/src/content/modules/maintaining-open-source-projects/fostering-a-strong-and-inclusive-community.mdx
@@ -1,7 +1,7 @@
 ---
 id: 4
 title: 'Fostering a Strong and Inclusive Community'
-metaDescription: 'Learn how to foster a strong and inclusive community around your Open Source project.'
+description: 'Learn how to foster a strong and inclusive community around your Open Source project.'
 creationDate: '2023-09-23'
 lastUpdateDate: '2023-09-23'
 ---

--- a/src/content/modules/maintaining-open-source-projects/index.mdx
+++ b/src/content/modules/maintaining-open-source-projects/index.mdx
@@ -2,7 +2,6 @@
 id: 5
 title: 'Maintaining Open Source Projects'
 description: 'Learn the essential strategies and best practices for successfully maintaining Open Source projects. Master project management and community engagement.'
-metaDescription: 'Learn the essential strategies and best practices for successfully maintaining Open Source projects. Master project management and community engagement.'
 ---
 <p class="lead">Maintaining Open Source projects comes with a unique set of challenges that require careful consideration and proactive management. In this module, we will delve into the tasks that maintainers often encounter during their journey of sustaining and nurturing Open Source initiatives.</p>
 

--- a/src/content/modules/maintaining-open-source-projects/introduction-to-open-source-project-maintenance.mdx
+++ b/src/content/modules/maintaining-open-source-projects/introduction-to-open-source-project-maintenance.mdx
@@ -1,7 +1,7 @@
 ---
 id: 1
 title: 'Introduction to Open Source Project Maintenance'
-metaDescription: 'Discover the essence of Open Source project maintenance. From nurturing collaboration to proactive management, learn the key principles of keeping your Open Source project thriving. Dive into the world of OSS with this comprehensive guide.'
+description: 'Discover the essence of Open Source project maintenance. From nurturing collaboration to proactive management, learn the key principles of keeping your Open Source project thriving. Dive into the world of OSS with this comprehensive guide.'
 creationDate: '2023-10-06'
 lastUpdateDate: '2023-10-06'
 ---

--- a/src/content/modules/maintaining-open-source-projects/managing-contributions-and-community-engagement.mdx
+++ b/src/content/modules/maintaining-open-source-projects/managing-contributions-and-community-engagement.mdx
@@ -1,6 +1,6 @@
 ---
 id: 2
 title: 'Managing Contributions and Community Engagement'
-metaDescription: ""
+description: ""
 soon: true
 ---

--- a/src/content/modules/maintaining-open-source-projects/managing-project-dependencies.mdx
+++ b/src/content/modules/maintaining-open-source-projects/managing-project-dependencies.mdx
@@ -1,6 +1,6 @@
 ---
 id: 3
 title: 'Managing Project Dependencies'
-metaDescription: ""
+description: ""
 soon: true
 ---

--- a/src/content/modules/promoting-open-source-projects/index.mdx
+++ b/src/content/modules/promoting-open-source-projects/index.mdx
@@ -2,7 +2,6 @@
 id: 6
 title: 'Promoting Open Source Projects'
 description: 'Discover effective strategies to promote Open Source projects, engage the community, and increase adoption. Unlock the power of open collaboration.'
-metaDescription: 'Discover effective strategies to promote Open Source projects, engage the community, and increase adoption. Unlock the power of open collaboration.'
 ---
 <p class="lead">Promoting Open Source projects requires a set of strategies and techniques that can help you effectively promote your Open Source projects, engage the community, and drive increased adoption.</p>
 

--- a/src/content/modules/what-is-open-source/brief-history-of-open-source.mdx
+++ b/src/content/modules/what-is-open-source/brief-history-of-open-source.mdx
@@ -1,7 +1,7 @@
 ---
 id: 2
 title: 'Brief History of Open Source'
-metaDescription: 'Explore the history and evolution of Open Source from computing roots to its emergence as a philosophy changing software development. Discover its impact today!'
+description: 'Explore the history and evolution of Open Source from computing roots to its emergence as a philosophy changing software development. Discover its impact today!'
 creationDate: '2023-04-02'
 lastUpdateDate: '2023-04-05'
 ---

--- a/src/content/modules/what-is-open-source/definition-of-open-source.mdx
+++ b/src/content/modules/what-is-open-source/definition-of-open-source.mdx
@@ -1,7 +1,7 @@
 ---
 id: 1
 title: Definition of Open Source
-metaDescription: 'Explore the philosophy behind Open Source and how it enables collaborative, innovative development of tech, art, and knowledge. Learn how communities work together!'
+description: 'Explore the philosophy behind Open Source and how it enables collaborative, innovative development of tech, art, and knowledge. Learn how communities work together!'
 creationDate: '2023-04-02'
 lastUpdateDate: '2023-04-05'
 ---

--- a/src/content/modules/what-is-open-source/examples-of-successful-open-source-projects.mdx
+++ b/src/content/modules/what-is-open-source/examples-of-successful-open-source-projects.mdx
@@ -1,7 +1,7 @@
 ---
 id: 4
 title: 'Examples of Successful Open Source Projects'
-metaDescription: 'Explore successful and impactful Open Source projects that transformed industries and challenged proprietary models. Discover their history, features, and impact. Join the movement!'
+description: 'Explore successful and impactful Open Source projects that transformed industries and challenged proprietary models. Discover their history, features, and impact. Join the movement!'
 creationDate: '2023-04-09'
 lastUpdateDate: '2023-04-09'
 ---

--- a/src/content/modules/what-is-open-source/index.mdx
+++ b/src/content/modules/what-is-open-source/index.mdx
@@ -2,7 +2,6 @@
 id: 1
 title: 'What Is Open Source?'
 description: 'Cover Open Source definition, brief history, and importance. Learn how community-driven innovation empowers developers.'
-metaDescription: 'Join the Open Source movement and discover how it changes development methodology, technology, art, and knowledge sharing. Be a part of the change today!'
 ---
 <p class="lead">Open Source is a collaborative development methodology and philosophy that is changing the way in which not just software but various forms of technology, art, and knowledge are developed and shared.</p>
 

--- a/src/content/modules/what-is-open-source/the-significance-of-open-source.mdx
+++ b/src/content/modules/what-is-open-source/the-significance-of-open-source.mdx
@@ -1,7 +1,7 @@
 ---
 id: 3
 title: 'The Significance of Open Source'
-metaDescription: "Discover the profound impact of Open Source beyond code. Explore how it empowers innovation, fosters collaboration, and drives positive change in society."
+description: "Discover the profound impact of Open Source beyond code. Explore how it empowers innovation, fosters collaboration, and drives positive change in society."
 creationDate: '2023-04-02'
 lastUpdateDate: '2023-10-05'
 ---

--- a/src/content/modules/what-is-open-source/types-of-open-source-projects.mdx
+++ b/src/content/modules/what-is-open-source/types-of-open-source-projects.mdx
@@ -1,7 +1,7 @@
 ---
 id: 5
 title: 'Types of Open Source Projects'
-metaDescription: "Explore the diverse world of Open Source projects! Learn about Open Source Software, Hardware, Data, Communities, and more in this comprehensive guide. Dive into the heart of collaborative innovation."
+description: "Explore the diverse world of Open Source projects! Learn about Open Source Software, Hardware, Data, Communities, and more in this comprehensive guide. Dive into the heart of collaborative innovation."
 creationDate: '2023-10-05'
 lastUpdateDate: '2023-10-05'
 ---

--- a/src/content/modules/what-is-open-source/types-of-open-source-software-projects.mdx
+++ b/src/content/modules/what-is-open-source/types-of-open-source-software-projects.mdx
@@ -1,7 +1,7 @@
 ---
 id: 6
 title: 'Types of Open Source Software Projects'
-metaDescription: "Uncover the world of Open Source projects, from operating systems to content management systems. Explore the diverse landscape of Open Source Software development."
+description: "Uncover the world of Open Source projects, from operating systems to content management systems. Explore the diverse landscape of Open Source Software development."
 creationDate: '2023-10-06'
 lastUpdateDate: '2023-10-06'
 ---

--- a/src/pages/guide/[...slug].astro
+++ b/src/pages/guide/[...slug].astro
@@ -49,7 +49,7 @@ const { entry, isIndex, orderedFilteredChapters, module } = Astro.props;
 const { Content } = await entry.render();
 ---
 { isIndex && (
-<Layout title={ entry.data.title } description={ entry.data.metaDescription } openGraphData={{title: entry.data.title, type: "website", description: entry.data.metaDescription}}>
+<Layout title={ entry.data.title } description={ entry.data.description } openGraphData={{title: entry.data.title, type: "website", description: entry.data.description}}>
   <div class="bg-base-100 pb-8 flex flex-col justify-center relative overflow-hidden xl:pb-12">
     <div class="md:max-w-3xl md:mx-auto lg:max-w-4xl lg:pt-4 lg:pb-4">
       <div class="text-sm breadcrumbs px-2">
@@ -91,7 +91,7 @@ const { Content } = await entry.render();
 )}
 
 { !isIndex && (
-<Layout title={ entry.data.title } description={ entry.data.metaDescription } progressScroll={true} openGraphData={{title: entry.data.title, type: "article", description: entry.data.metaDescription}}>
+<Layout title={ entry.data.title } description={ entry.data.description } progressScroll={true} openGraphData={{title: entry.data.title, type: "article", description: entry.data.description}}>
   <div class="text-sm breadcrumbs pb-8">
     <ul>
       <li><a href="/guide">Guide</a></li>


### PR DESCRIPTION
### Related issues

Closes #292

### Description

This PR gets rid of `metaDescription` to replace it with `description`. Places were defining both texts are now using only one.

### Type of changes

- Enhancement (non-breaking change)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Open-reSource/openresource.dev/blob/main/CONTRIBUTING.md)
