### PR TITLE
Fix Content Encoding Error on 404 pages

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,5 +1,5 @@
 ---
-export const prerender = true
+export const prerender = false
 
 import Layout from '../layouts/Layout.astro';
 

--- a/src/util/getOpenGraphImageURL.ts
+++ b/src/util/getOpenGraphImageURL.ts
@@ -1,8 +1,3 @@
-import type { GetStaticPathsOptions, GetStaticPathsResult } from 'astro';
-import { getStaticPaths } from '../pages/open-graph/[...path]';
-
-const routes = (await getStaticPaths({} as GetStaticPathsOptions)) as GetStaticPathsResult;
-
 /**
  * Get the path to the Open Graph image for a page
  * @param path Pathname of the page URL.


### PR DESCRIPTION
⚠️ This PR is a draft

---

### Description

404 pages generate a Content Encoding Error in the production configuration and with the main branch configuration. However, in the deployment of this branch and locally, it's working:

* 🔴 https://openresource.dev/articles/fdsfsdfsd
* 🔴 https://main-branch-openresource-dev-git-main-open-resource.vercel.app/fdsqfdsfsqd
* 🟢 https://main-branch-openresource-dev-git-main-jd-fix-404-open-resource.vercel.app/dskfdsfdfds
* 🟢 https://main-branch-openresource-dev-git-main-jd-fix-404-open-resource.vercel.app/articles/dskfdsfdfds

One solution seems to be to use `export const prerender = false` with `404.astro`. However, `npm run build` generated an error while running locally. The code using `getStaticPaths` wasn't used so is removed.

It's not possible to check whether or not this fix will work in production so let's merge and see 🤞 