### PR TITLE
chore(deps): bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,14 +7,14 @@
     "": {
       "version": "0.0.1",
       "dependencies": {
-        "@astrojs/markdown-remark": "^4.0.0",
-        "@astrojs/mdx": "^2.0.0",
+        "@astrojs/markdown-remark": "^4.0.1",
+        "@astrojs/mdx": "^2.0.1",
         "@astrojs/rss": "^4.0.1",
         "@astrojs/sitemap": "^3.0.3",
         "@astrojs/tailwind": "^5.0.3",
-        "@astrojs/vercel": "^6.0.1",
+        "@astrojs/vercel": "^6.0.2",
         "@vercel/analytics": "^1.1.1",
-        "astro": "^4.0.3",
+        "astro": "^4.0.4",
         "daisyui": "^4.4.19",
         "gemoji": "^8.1.0",
         "tailwindcss": "^3.3.6",
@@ -266,9 +266,9 @@
       "integrity": "sha512-06DD2ZnItMwUnH81LBLco3tWjcZ1lGU9rLCCBaeUCGYe9cI0wKyY2W3kDyoW1I6GmcWgt1fu+D1CTvz+FIKf8A=="
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-4.0.0.tgz",
-      "integrity": "sha512-JSrn49fJGuH/0S2TTGxLK7bNDspOakJWZVFHeP+IDFjWdghT4HtsTShS2EiISNx3zfOFBAwy5Cj4xT4U5BWNeA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-4.0.1.tgz",
+      "integrity": "sha512-RU4ESnqvyLpj8WZs0n5elS6idaDdtIIm7mIpMaRNPCebpxMjfcfdwcmBwz83ktAj5d2eO5bC3z92TcGdli+lRw==",
       "dependencies": {
         "@astrojs/prism": "^3.0.0",
         "github-slugger": "^2.0.0",
@@ -284,9 +284,6 @@
         "unified": "^11.0.4",
         "unist-util-visit": "^5.0.0",
         "vfile": "^6.0.1"
-      },
-      "peerDependencies": {
-        "astro": "^4.0.0-beta.0"
       }
     },
     "node_modules/@astrojs/markdown-remark/node_modules/@types/unist": {
@@ -405,11 +402,11 @@
       }
     },
     "node_modules/@astrojs/mdx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-2.0.0.tgz",
-      "integrity": "sha512-VT5HnnOETk2gmdlheSlSBtYIsS0PQF/bEgZDjhc0VngdZstR90kt1NVns/Jj8q7G5lMZp8/9ZOHwwBbAhVk2zA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-2.0.1.tgz",
+      "integrity": "sha512-lWbiNoVV/6DO8hAf6eZmcN28hY/herif9eglw2PXZ5lEPoRu175BvBtuNTt9rH9YA/Ldm5mkNXhvMWNEnMqJkw==",
       "dependencies": {
-        "@astrojs/markdown-remark": "4.0.0",
+        "@astrojs/markdown-remark": "4.0.1",
         "@mdx-js/mdx": "^3.0.0",
         "acorn": "^8.11.2",
         "es-module-lexer": "^1.4.1",
@@ -429,7 +426,7 @@
         "node": ">=18.14.1"
       },
       "peerDependencies": {
-        "astro": "^4.0.0-beta.0"
+        "astro": "^4.0.0"
       }
     },
     "node_modules/@astrojs/mdx/node_modules/@types/unist": {
@@ -576,9 +573,9 @@
       }
     },
     "node_modules/@astrojs/vercel": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-6.0.1.tgz",
-      "integrity": "sha512-VX32LMSWdV2BvoEW3GcD6hBlE+oZ+zU3pbvX4P2tGMjqE4Em9RDb4GYyvwhncsISQD9jgEwjWmvqT/koSIVBxQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-6.0.2.tgz",
+      "integrity": "sha512-2uk5M0Hei/mMJ3y7Hq4HBNg6RXWHCYa/C3n5uejtKzIlBz2HZ94LsXwEjx7jT/iOvR/CyfhnVLYeB46pw3v0wQ==",
       "dependencies": {
         "@astrojs/internal-helpers": "0.2.1",
         "@vercel/analytics": "^1.0.2",
@@ -3231,13 +3228,13 @@
       }
     },
     "node_modules/astro": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-4.0.3.tgz",
-      "integrity": "sha512-hrwe7CIVhSKW8/iibDs1hpqzZAtvx6Qu8TFFxjaGbooEWF720M9L+ZZtyTgrcy6K/ZHJ0xwFvZV3/X2Vvbf/LQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-4.0.4.tgz",
+      "integrity": "sha512-KhwoF5//kFusczKN46ZG185uk9BQt1OH5949wsrFKs0z7Oo/o31XyxKyqIW8ZSL0fWU4XYKSdYlAo1RaPF9TtA==",
       "dependencies": {
         "@astrojs/compiler": "^2.3.2",
         "@astrojs/internal-helpers": "0.2.1",
-        "@astrojs/markdown-remark": "4.0.0",
+        "@astrojs/markdown-remark": "4.0.1",
         "@astrojs/telemetry": "3.0.4",
         "@babel/core": "^7.23.3",
         "@babel/generator": "^7.23.3",
@@ -12795,9 +12792,9 @@
       "integrity": "sha512-06DD2ZnItMwUnH81LBLco3tWjcZ1lGU9rLCCBaeUCGYe9cI0wKyY2W3kDyoW1I6GmcWgt1fu+D1CTvz+FIKf8A=="
     },
     "@astrojs/markdown-remark": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-4.0.0.tgz",
-      "integrity": "sha512-JSrn49fJGuH/0S2TTGxLK7bNDspOakJWZVFHeP+IDFjWdghT4HtsTShS2EiISNx3zfOFBAwy5Cj4xT4U5BWNeA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-4.0.1.tgz",
+      "integrity": "sha512-RU4ESnqvyLpj8WZs0n5elS6idaDdtIIm7mIpMaRNPCebpxMjfcfdwcmBwz83ktAj5d2eO5bC3z92TcGdli+lRw==",
       "requires": {
         "@astrojs/prism": "^3.0.0",
         "github-slugger": "^2.0.0",
@@ -12901,11 +12898,11 @@
       }
     },
     "@astrojs/mdx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-2.0.0.tgz",
-      "integrity": "sha512-VT5HnnOETk2gmdlheSlSBtYIsS0PQF/bEgZDjhc0VngdZstR90kt1NVns/Jj8q7G5lMZp8/9ZOHwwBbAhVk2zA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-2.0.1.tgz",
+      "integrity": "sha512-lWbiNoVV/6DO8hAf6eZmcN28hY/herif9eglw2PXZ5lEPoRu175BvBtuNTt9rH9YA/Ldm5mkNXhvMWNEnMqJkw==",
       "requires": {
-        "@astrojs/markdown-remark": "4.0.0",
+        "@astrojs/markdown-remark": "4.0.1",
         "@mdx-js/mdx": "^3.0.0",
         "acorn": "^8.11.2",
         "es-module-lexer": "^1.4.1",
@@ -13034,9 +13031,9 @@
       }
     },
     "@astrojs/vercel": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-6.0.1.tgz",
-      "integrity": "sha512-VX32LMSWdV2BvoEW3GcD6hBlE+oZ+zU3pbvX4P2tGMjqE4Em9RDb4GYyvwhncsISQD9jgEwjWmvqT/koSIVBxQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/vercel/-/vercel-6.0.2.tgz",
+      "integrity": "sha512-2uk5M0Hei/mMJ3y7Hq4HBNg6RXWHCYa/C3n5uejtKzIlBz2HZ94LsXwEjx7jT/iOvR/CyfhnVLYeB46pw3v0wQ==",
       "requires": {
         "@astrojs/internal-helpers": "0.2.1",
         "@vercel/analytics": "^1.0.2",
@@ -15014,13 +15011,13 @@
       "integrity": "sha512-ISvCdHdlTDlH5IpxQJIex7BWBywFWgjJSVdwst+/iQCoEYnyOaQ95+X1JGshuBjGp6nxKUy1jMgE3zPqN7fQdg=="
     },
     "astro": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-4.0.3.tgz",
-      "integrity": "sha512-hrwe7CIVhSKW8/iibDs1hpqzZAtvx6Qu8TFFxjaGbooEWF720M9L+ZZtyTgrcy6K/ZHJ0xwFvZV3/X2Vvbf/LQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-4.0.4.tgz",
+      "integrity": "sha512-KhwoF5//kFusczKN46ZG185uk9BQt1OH5949wsrFKs0z7Oo/o31XyxKyqIW8ZSL0fWU4XYKSdYlAo1RaPF9TtA==",
       "requires": {
         "@astrojs/compiler": "^2.3.2",
         "@astrojs/internal-helpers": "0.2.1",
-        "@astrojs/markdown-remark": "4.0.0",
+        "@astrojs/markdown-remark": "4.0.1",
         "@astrojs/telemetry": "3.0.4",
         "@babel/core": "^7.23.3",
         "@babel/generator": "^7.23.3",

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "update:showcase": "tsx scripts/update-showcase.ts"
   },
   "dependencies": {
-    "@astrojs/markdown-remark": "^4.0.0",
-    "@astrojs/mdx": "^2.0.0",
+    "@astrojs/markdown-remark": "^4.0.1",
+    "@astrojs/mdx": "^2.0.1",
     "@astrojs/rss": "^4.0.1",
     "@astrojs/sitemap": "^3.0.3",
     "@astrojs/tailwind": "^5.0.3",
-    "@astrojs/vercel": "^6.0.1",
+    "@astrojs/vercel": "^6.0.2",
     "@vercel/analytics": "^1.1.1",
-    "astro": "^4.0.3",
+    "astro": "^4.0.4",
     "daisyui": "^4.4.19",
     "gemoji": "^8.1.0",
     "tailwindcss": "^3.3.6",


### PR DESCRIPTION
- `@astrojs/markdown-remark`: 4.0.0 → 4.0.1
- `@astrojs/mdx`: 2.0.0 → 2.0.1
- `@astrojs/vercel`: 6.0.1 → 6.0.2
- `astro`: 4.0.3 → 4.0.4