### PR TITLE
chore(deps): add `@vercel/speed-insights`

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -41,9 +41,6 @@ export default defineConfig({
   adapter: vercel({
     webAnalytics: {
       enabled: true
-    },
-    speedInsights: {
-      enabled: true
     }
   }),
   site: 'https://openresource.dev',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@astrojs/tailwind": "^5.1.0",
         "@astrojs/vercel": "^7.6.0",
         "@vercel/analytics": "^1.2.2",
+        "@vercel/speed-insights": "^1.0.10",
         "astro": "^4.8.4",
         "daisyui": "^4.11.1",
         "gemoji": "^8.1.0",
@@ -3889,6 +3890,40 @@
       "resolved": "https://registry.npmjs.org/@vercel/ruby/-/ruby-2.1.0.tgz",
       "integrity": "sha512-UZYwlSEEfVnfzTmgkD+kxex9/gkZGt7unOWNyWFN7V/ZnZSsGBUgv6hXLnwejdRi3EztgRQEBd1kUKlXdIeC0Q==",
       "dev": true
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.0.10.tgz",
+      "integrity": "sha512-4uzdKB0RW6Ff2FkzshzjZ+RlJfLPxgm/00i0XXgxfMPhwnnsk92YgtqsxT9OcPLdJUyVU1DqFlSWWjIQMPkh0g==",
+      "hasInstallScript": true,
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19",
+        "svelte": "^4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vercel/static-build": {
       "version": "2.5.9",
@@ -15817,6 +15852,12 @@
       "resolved": "https://registry.npmjs.org/@vercel/ruby/-/ruby-2.1.0.tgz",
       "integrity": "sha512-UZYwlSEEfVnfzTmgkD+kxex9/gkZGt7unOWNyWFN7V/ZnZSsGBUgv6hXLnwejdRi3EztgRQEBd1kUKlXdIeC0Q==",
       "dev": true
+    },
+    "@vercel/speed-insights": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.0.10.tgz",
+      "integrity": "sha512-4uzdKB0RW6Ff2FkzshzjZ+RlJfLPxgm/00i0XXgxfMPhwnnsk92YgtqsxT9OcPLdJUyVU1DqFlSWWjIQMPkh0g==",
+      "requires": {}
     },
     "@vercel/static-build": {
       "version": "2.5.9",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@astrojs/tailwind": "^5.1.0",
     "@astrojs/vercel": "^7.6.0",
     "@vercel/analytics": "^1.2.2",
+    "@vercel/speed-insights": "^1.0.10",
     "astro": "^4.8.4",
     "daisyui": "^4.11.1",
     "gemoji": "^8.1.0",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,6 @@
 ---
+import  SpeedInsights  from '@vercel/speed-insights/astro';
+
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import '../global.css';
@@ -95,6 +97,7 @@ if (structuredData?.article) {
 		</main>
 		<Footer divider={ !home } />
     { progressScroll && <ProgressScroll /> }
+    <SpeedInsights />
 	</body>
 </html>
 <script>


### PR DESCRIPTION
### Description

`speedInsights` configuration was marked as deprecated in `@astrojs/vercel` version 6.1.3. Vercel has migrated features of the Speed Insights API into a framework-agnostic library with `@vercel/speed-insights`. See [Vercel Speed Insights Quickstart](https://vercel.com/docs/speed-insights/quickstart) for instructions on how to use the library instead.

<img width="1226" alt="Screenshot 2024-05-16 at 18 03 38" src="https://github.com/Open-reSource/openresource.dev/assets/17381666/a3294f7e-0c53-4c80-81cf-ad94b0cc728c">

This PR intends to do this migration.
