### PR TITLE
feat: add `finished: false` frontmatter option for chapters

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -39,6 +39,7 @@ const modulesCollection = defineCollection({
     id: z.number(),
     creationDate: z.string().optional(),
     description: z.string(),
+    finished: z.boolean().optional(),
     lastUpdateDate: z.string().optional(),
     title: z.string(),
     soon: z.boolean().optional(),

--- a/src/content/modules/creating-your-own-open-source-project/developing-your-project.mdx
+++ b/src/content/modules/creating-your-own-open-source-project/developing-your-project.mdx
@@ -4,6 +4,7 @@ title: 'Developing Your Project'
 description: "Learn the ins and outs of developing an open-source project, from setting up a collaborative environment to managing contributions and ensuring scalability. Follow these best practices to create a successful and welcoming open-source project."
 creationDate: '2024-03-30'
 lastUpdateDate: '2024-03-30'
+finished: false
 ---
 <p class="lead">**You've set up your project repository and you're ready to start developing your own open-source project. This is where the real fun begins!**</p>
 
@@ -62,8 +63,3 @@ As you open up your project to the community, you'll start receiving feedback an
 * **Enabling discussions on your repository** can also provide a platform for users and contributors to engage with each other, share ideas, and provide feedback on the project.
 
 * **Setting up a dedicated communication channel** is also possible such as a Discord server or a mailing list, to facilitate real-time communication and collaboration among contributors. However, it might not be necessary right away so we'll keep it for later.
-
-<div role="alert" class="alert alert-warning">
-  <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
-  <span>**Warning:** This chapter isn't finished yet! More content soon!</span>
-</div>

--- a/src/content/modules/creating-your-own-open-source-project/legal-considerations.mdx
+++ b/src/content/modules/creating-your-own-open-source-project/legal-considerations.mdx
@@ -4,6 +4,7 @@ title: 'Legal Considerations'
 description: "Learn how to manage legal considerations in open-source projects. Understand licenses, compliance, and risk mitigation strategies."
 creationDate: '2024-02-06'
 lastUpdateDate: '2024-02-06'
+finished: false
 ---
 
 <p class="lead">Legal considerations are a very important aspect of open-source projects, often shaping their structure, growth, and community interactions. They help define the rules of the game in a healthy and collaborative environment. They determine how others can use, modify, and distribute your project. They protect your rights as a creator, while also respecting the rights of contributors and users. They can even influence the adoption and success of your project.</p>

--- a/src/content/modules/maintaining-open-source-projects/fostering-a-strong-and-inclusive-community.mdx
+++ b/src/content/modules/maintaining-open-source-projects/fostering-a-strong-and-inclusive-community.mdx
@@ -4,6 +4,7 @@ title: 'Fostering a Strong and Inclusive Community'
 description: 'Learn how to foster a strong and inclusive community around your open-source project.'
 creationDate: '2023-09-23'
 lastUpdateDate: '2023-09-23'
+finished: false
 ---
 <p class="lead">A strong and inclusive community is essential for the success of any open-source project. It is the community that drives the project forward, and it is the community that will ultimately determine its success or failure.</p>
 

--- a/src/pages/guide/[...slug].astro
+++ b/src/pages/guide/[...slug].astro
@@ -113,6 +113,14 @@ const { Content } = await entry.render();
             </svg><span class="visually-hidden">Estimated reading time</span>{ Math.ceil(readingTime(entry.body).minutes) } min</span>
           </div>
           <Content />
+          {
+            entry.data.finished === false && (
+              <div role="alert" class="alert alert-warning">
+                <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
+                <span><span class="font-bold">Warning:</span> This chapter isn't finished yet! More content soon!</span>
+              </div>
+            )
+          }
           <hr>
           <Feedback id={entry.id} type="modules" />
           <CreativeCommonMention />


### PR DESCRIPTION
### Description

At the time of writing this PR, most of the modules, and their chapters, are not entirely written or structured with a final version in mind. An information needs to be displayed at the end of these chapters to inform the reader that this chapter is not considered as "finished" (even if they will never be finished, they could contain at least the topics I'd like to tackle in the first place).

This PR adds a "finished" optional frontmatter option.

When there's a `finished: false` in the frontmatter, there's a warning banner displayed at the end of the chapter.

This PR also flags some chapters as "not finished" that weren't flagged like this before.

### Type of changes

- New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Open-reSource/openresource.dev/blob/main/CONTRIBUTING.md)
