### PR TITLE
chore(deps-dev): bump starlight-blog from 0.12.0 to 0.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "linkedom": "^0.18.5",
         "parse-github-url": "^1.0.3",
         "reading-time": "^1.5.0",
-        "starlight-blog": "^0.12.0",
+        "starlight-blog": "^0.13.0",
         "starlight-links-validator": "^0.12.1",
         "starlight-showcases": "^0.2.0",
         "tsx": "^4.19.1",
@@ -9335,9 +9335,9 @@
       "dev": true
     },
     "node_modules/starlight-blog": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/starlight-blog/-/starlight-blog-0.12.0.tgz",
-      "integrity": "sha512-SSNkBQIM6RrumGQQqOv76L5Lcefm6faU2+4armlgQh2zod24aOvuCGUcFi3F//DxOWvIx3WRb7X/VRqs3yNO8A==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/starlight-blog/-/starlight-blog-0.13.0.tgz",
+      "integrity": "sha512-AQi+5PdsgN/ltQh1j+F/crHLlBFwDUOKgW8H1GnzLUq2T6J7VaOVf62fmCfBDmymfBN4mOfIZuJXq5ZzY3pJmQ==",
       "dev": true,
       "dependencies": {
         "@astrojs/rss": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "linkedom": "^0.18.5",
     "parse-github-url": "^1.0.3",
     "reading-time": "^1.5.0",
-    "starlight-blog": "^0.12.0",
+    "starlight-blog": "^0.13.0",
     "starlight-links-validator": "^0.12.1",
     "starlight-showcases": "^0.2.0",
     "tsx": "^4.19.1",

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -9,10 +9,11 @@ const filteredAstroPropsId = Astro.props.id.replace(/\/index./, '.');
 
 // Force the og:image to be the index image for the homepage for these kind of pages:
 // - articles/tags/*
+// - articles/authors/*
 // - 404
 // - articles.*
 // - articles/[0-9]*/
-const isOgIndex = Astro.props.id.startsWith('articles/tags/') || Astro.props.id.startsWith('articles.') || /^articles\/\d+/.test(Astro.props.id) || Astro.props.id.startsWith('404');
+const isOgIndex = Astro.props.id.startsWith('articles/tags/') || Astro.props.id.startsWith('articles.') || /^articles\/\d+/.test(Astro.props.id) || Astro.props.id.startsWith('404') || Astro.props.id.startsWith('articles/authors/');
 
 // Get the URL of the generated image for the current page using its
 // ID and replace the file extension with `.png`.
@@ -24,7 +25,7 @@ const ogImageUrl = new URL(
 const { entry } = Astro.props;
 const { data } = entry;
 
-const isArticle = Astro.props.slug.startsWith('articles/') && !Astro.props.slug.startsWith('articles/tags') && !Astro.props.slug.match('articles/[0-9]*$');
+const isArticle = Astro.props.slug.startsWith('articles/') && !Astro.props.slug.startsWith('articles/tags') && !Astro.props.slug.startsWith('articles/authors') && !Astro.props.slug.match('articles/[0-9]*$');
 
 let articleSchema;
 if (isArticle) {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,7 +3,7 @@ import type { Props } from '@astrojs/starlight/props';
 import Default from '@astrojs/starlight/components/Header.astro';
 import ProgressScroll from './ProgressScroll.astro';
 
-const displayProgressScroll = Astro.props.slug.startsWith('guide') || Astro.props.slug.startsWith('articles/') && !Astro.props.slug.startsWith('articles/tags') && !Astro.props.slug.match('articles/[0-9]*$');
+const displayProgressScroll = Astro.props.slug.startsWith('guide') || Astro.props.slug.startsWith('articles/') && !Astro.props.slug.startsWith('articles/tags') && !Astro.props.slug.startsWith('articles/authors') && !Astro.props.slug.match('articles/[0-9]*$');
 ---
 <Default {...Astro.props}>
   <slot />

--- a/src/components/PageTitleThenReadingTime.astro
+++ b/src/components/PageTitleThenReadingTime.astro
@@ -7,7 +7,7 @@ const { date } = Astro.props.entry.data;
 const { entry, lang } = Astro.props;
 
 const isGuide = Astro.props.slug.startsWith('guide');
-const displayReadingTime = (isGuide && date) || Astro.props.slug.startsWith('articles') && !Astro.props.slug.startsWith('articles/tags');
+const displayReadingTime = (isGuide && date) || Astro.props.slug.startsWith('articles') && !Astro.props.slug.startsWith('articles/tags') && !Astro.props.slug.startsWith('articles/authors');
 const displayDate = date && isGuide;
 ---
 


### PR DESCRIPTION
### Description

This PR bumps starlight-blog from 0.12.0 to 0.13.0. [This new release](https://github.com/HiDeoo/starlight-blog/releases/tag/v0.13.0) embeds a new feature that mainly does not have any impacts on the rendering as there's only one author for the articles.

However, when running `npm run build`, we can see that a new page is generated: [/articles/authors/julien-déramond](https://main-branch-openresource-dev-git-main-jd-b-9868b2-open-resource.vercel.app/articles/authors/julien-d%C3%A9ramond)
This page is not an issue, but we want to remove the reading time, and maybe check at other places in the code if we need to do some other modifications. For instance, with the OG images.