### PR TITLE
fix(build): use `is:inline` to script embedded in `Head.astro`

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -80,4 +80,4 @@ if (isArticle) {
 
 <link href="https://fosstodon.org/@openresource" rel="me" />
 
-{articleSchema && <script type="application/ld+json" set:html={articleSchema} />}
+{articleSchema && <script is:inline type="application/ld+json" set:html={articleSchema} />}


### PR DESCRIPTION
### Description

This PR fixes the warning observed when running `npm run build`:

```fish
src/components/Head.astro:83:27 - warning astro(4000): This script will be treated as if it has the `is:inline` directive because it contains an attribute. Therefore, features that require processing (e.g. using TypeScript or npm packages in the script) are unavailable.

See docs for more details: https://docs.astro.build/en/guides/client-side-scripts/#script-processing.

Add the `is:inline` directive explicitly to silence this hint.

83 {articleSchema && <script type="application/ld+json" set:html={articleSchema} />}
```                             ~~~~
