### PR TITLE
fix(tests): `AssertionError: expected false to be true // Object.is equality`

### DIFF
--- a/tests/showcase.test.ts
+++ b/tests/showcase.test.ts
@@ -192,7 +192,7 @@ test('should delete the existing showcase content collection before saving showc
 	expect(mkdirMock).toHaveBeenCalledOnce();
 	expect(writeFileMock).toHaveBeenCalledOnce();
 	expect(rmMock.mock.invocationCallOrder < mkdirMock.mock.invocationCallOrder).toBe(true);
-	expect(mkdirMock.mock.invocationCallOrder < writeFileMock.mock.invocationCallOrder).toBe(true);
+	expect(mkdirMock).toHaveBeenCalledBefore(writeFileMock);
 });
 
 test('should save a showcase file per user', async () => {

--- a/tests/showcase.test.ts
+++ b/tests/showcase.test.ts
@@ -192,8 +192,9 @@ test('should delete the existing showcase content collection before saving showc
 	expect(mkdirMock).toHaveBeenCalledOnce();
 	expect(writeFileMock).toHaveBeenCalledOnce();
 	expect(rmMock.mock.invocationCallOrder < mkdirMock.mock.invocationCallOrder).toBe(true);
-  expect.hasAssertions();
+  expect(rmMock).toHaveBeenCalledOnce();
 	expect(mkdirMock.mock.invocationCallOrder < writeFileMock.mock.invocationCallOrder).toBe(true);
+  expect(mkdirMock).toHaveBeenCalledOnce();
 });
 
 test('should save a showcase file per user', async () => {

--- a/tests/showcase.test.ts
+++ b/tests/showcase.test.ts
@@ -192,6 +192,7 @@ test('should delete the existing showcase content collection before saving showc
 	expect(mkdirMock).toHaveBeenCalledOnce();
 	expect(writeFileMock).toHaveBeenCalledOnce();
 	expect(rmMock.mock.invocationCallOrder < mkdirMock.mock.invocationCallOrder).toBe(true);
+  expect.hasAssertions();
 	expect(mkdirMock.mock.invocationCallOrder < writeFileMock.mock.invocationCallOrder).toBe(true);
 });
 

--- a/tests/showcase.test.ts
+++ b/tests/showcase.test.ts
@@ -192,9 +192,7 @@ test('should delete the existing showcase content collection before saving showc
 	expect(mkdirMock).toHaveBeenCalledOnce();
 	expect(writeFileMock).toHaveBeenCalledOnce();
 	expect(rmMock.mock.invocationCallOrder < mkdirMock.mock.invocationCallOrder).toBe(true);
-  expect(rmMock).toHaveBeenCalledOnce();
 	expect(mkdirMock.mock.invocationCallOrder < writeFileMock.mock.invocationCallOrder).toBe(true);
-  expect(mkdirMock).toHaveBeenCalledOnce();
 });
 
 test('should save a showcase file per user', async () => {


### PR DESCRIPTION
 for 'should delete the existing showcase content collection before saving showcases to handle deleted comments' test

### Description

The test suite worked locally but not anymore in GitHub integration testing context (without any changes).

### Type of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/Open-reSource/openresource.dev/blob/main/CONTRIBUTING.md)
